### PR TITLE
Add User Menu

### DIFF
--- a/src/components/login-form/login-form.jsx
+++ b/src/components/login-form/login-form.jsx
@@ -30,7 +30,6 @@ const LoginForm = (props) => {
     if(!response)
       return;
     
-    props.showNotification(response.message, "info", true);
     props.goToDashboard();
   };
 
@@ -98,7 +97,6 @@ LoginForm.propTypes = {
   authInProgress: PropTypes.bool.isRequired,
   authenticate: PropTypes.func.isRequired,
   showSignUpForm: PropTypes.func.isRequired,
-  showNotification: PropTypes.func.isRequired,
   goToDashboard: PropTypes.func.isRequired,
   authError: PropTypes.string,
   dataTestId: PropTypes.string

--- a/src/components/login-form/login-form.spec.jsx
+++ b/src/components/login-form/login-form.spec.jsx
@@ -17,7 +17,6 @@ describe("<LoginForm />", () => {
           username: "testUser"
         }
       }),
-      showNotification: jest.fn(),
       goToDashboard: jest.fn()
     };
   });
@@ -87,7 +86,7 @@ describe("<LoginForm />", () => {
     expect(props.authenticate).toHaveBeenCalledWith("testUser", "Password1");
   });
 
-  it("should show a success notification and redirect the user to the dashboard", async () => {
+  it("should redirect the user to the dashboard if authentication succeeds", async () => {
     const { getByTestId } = render(<LoginForm {...props}/>);
     const button = getByTestId(`${props.dataTestId}.loginButton`);
     const usernameInput = getByTestId(`${props.dataTestId}.usernameInput.input`);
@@ -104,15 +103,10 @@ describe("<LoginForm />", () => {
       }
     });
     fireEvent.click(button);
-    await waitFor(() => expect(props.showNotification).toHaveBeenCalledWith(
-      "mock auth success",
-      "info",
-      true
-    ));
     await waitFor(() => expect(props.goToDashboard).toHaveBeenCalled());
   });
 
-  it("should not show a notification or redirect the user if authentication fails", async () => {
+  it("should not redirect the user if authentication fails", async () => {
     props.authenticate.mockReturnValueOnce(undefined);
     const { getByTestId } = render(<LoginForm {...props}/>);
     const button = getByTestId(`${props.dataTestId}.loginButton`);
@@ -130,7 +124,6 @@ describe("<LoginForm />", () => {
       }
     });
     fireEvent.click(button);
-    await waitFor(() => expect(props.showNotification).toHaveBeenCalledTimes(0));
     await waitFor(() => expect(props.goToDashboard).toHaveBeenCalledTimes(0));
   });
 

--- a/src/components/tooltip/tooltip.spec.jsx
+++ b/src/components/tooltip/tooltip.spec.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Tooltip from "./tooltip";
 import { render } from "../../test-utils";
 
-describe("<LoginForm />", () => {
+describe("<Tooltip />", () => {
   let props;
   beforeEach(() => {
     props = {

--- a/src/components/user-menu/user-menu-flyout.jsx
+++ b/src/components/user-menu/user-menu-flyout.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  FlyoutWrapper,
+  FlyoutItemList,
+  FlyoutMenuItem
+} from "./user-menu.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const Flyout = ({items, closeMenu, dataTestId}) => {
+  // Declare our clickHandler.
+  const _handleClick = useCallback(() => {
+    closeMenu();
+  }, [closeMenu]);
+
+  // Attach the clickHandler, if the menu is open, so we can close the menu when the next click happens.
+  useEffect(() => {
+    window.addEventListener("click", _handleClick);
+    return () => window.removeEventListener("click", _handleClick);
+  });
+
+  return (
+    <FlyoutWrapper data-testid={dataTestId}>
+      <FlyoutItemList>
+        {items.map(({icon, label, onClick}, index) => (
+          <FlyoutMenuItem key={index} onClick={onClick}>
+            <FontAwesomeIcon icon={icon} fixedWidth /> {label}
+          </FlyoutMenuItem>
+        ))}
+      </FlyoutItemList>
+    </FlyoutWrapper>
+  );
+};
+
+Flyout.propTypes = {
+  items: PropTypes.array.isRequired,
+  closeMenu: PropTypes.func.isRequired,
+  dataTestId: PropTypes.string
+};
+
+export default Flyout;

--- a/src/components/user-menu/user-menu.jsx
+++ b/src/components/user-menu/user-menu.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import UserMenuFlyout from "./user-menu-flyout";
+import { UserMenuWrapper } from "./user-menu.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCaretDown, faKey, faSignOutAlt } from "@fortawesome/free-solid-svg-icons";
+
+const UserMenu = ({userInfo, logout, dataTestId}) => {
+  const [flyoutIsOpen, setFlyoutIsOpen] = useState(false);
+  const flyoutItems = [{
+    icon: faKey,
+    label: "Change Password",
+    onClick: () => {console.log("show change password modal")}
+  },{
+    icon: faSignOutAlt,
+    label: "Sign Out",
+    onClick: logout
+  }];
+  
+  return (
+    <UserMenuWrapper>
+      <span data-testid={dataTestId} onClick={() => setFlyoutIsOpen(true)}>
+        {userInfo.displayName}<FontAwesomeIcon icon={faCaretDown} fixedWidth/>
+      </span>
+      {flyoutIsOpen && <UserMenuFlyout dataTestId={`${dataTestId}.flyout`} items={flyoutItems} closeMenu={() => setFlyoutIsOpen(false)} />}
+    </UserMenuWrapper>
+  );
+};
+
+UserMenu.propTypes = {
+  userInfo: PropTypes.object.isRequired,
+  logout: PropTypes.func.isRequired,
+  dataTestId: PropTypes.string
+};
+
+export default UserMenu;

--- a/src/components/user-menu/user-menu.spec.jsx
+++ b/src/components/user-menu/user-menu.spec.jsx
@@ -1,0 +1,100 @@
+import React from "react";
+import UserMenu from "./user-menu";
+import UserMenuFlyout from "./user-menu-flyout";
+import { render } from "../../test-utils";
+import { fireEvent } from "@testing-library/react";
+import { faKey, faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+
+describe("<UserMenu />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      dataTestId: "testingUserMenu",
+      userInfo: {
+        username: "testuser",
+        displayName: "testUser"
+      },
+      logout: jest.fn()
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<UserMenu {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the authenticated user's display name", () => {
+    const {getByTestId, queryByText} = render(<UserMenu {...props} />);
+    expect(getByTestId(props.dataTestId)).toBeDefined();
+    expect(queryByText(props.userInfo.username)).toBeNull();
+    expect(queryByText(props.userInfo.displayName)).toBeDefined();
+  });
+
+  it("should not render the menu flyout by default", () => {
+    const {queryByTestId} = render(<UserMenu {...props} />);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeNull();
+  });
+
+  it("should render the flyout once the user's display name is clicked", () => {
+    const {getByTestId} = render(<UserMenu {...props} />);
+    const menu = getByTestId(props.dataTestId);
+    fireEvent.click(menu);
+    expect(getByTestId(`${props.dataTestId}.flyout`)).toBeDefined();
+  });
+
+  it("should render the change password and sign out menu items", () => {
+    const {getByTestId, getByText} = render(<UserMenu {...props} />);
+    const menu = getByTestId(props.dataTestId);
+    fireEvent.click(menu);
+    expect(getByText("Change Password")).toBeDefined();
+    expect(getByText("Sign Out")).toBeDefined();
+  });
+});
+
+describe("<UserMenuFlyout />", () => {
+  let props;
+  beforeAll(() => {
+    props = {
+      dataTestId: "testUserMenuFlyout",
+      items: [{
+        icon: faKey,
+        label: "Unit Test Item 1",
+        onClick: jest.fn()
+      }, {
+        icon: faArrowLeft,
+        label: "Unit Test Item 2",
+        onClick: jest.fn()
+      }],
+      closeMenu: jest.fn()
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<UserMenuFlyout {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should call the closeMenu method on click", () => {
+    const {getByTestId} = render(<UserMenuFlyout {...props} />);
+    expect(getByTestId(props.dataTestId)).toBeDefined();
+    fireEvent.click(getByTestId(props.dataTestId));
+    expect(props.closeMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the menu items", () => {
+    const {getByText} = render(<UserMenuFlyout {...props} />);
+    expect(getByText(props.items[0].label)).toBeDefined();
+    expect(getByText(props.items[1].label)).toBeDefined();
+  });
+
+  it("should call the onClick method for each menu item when clicked", () => {
+    const {getByText} = render(<UserMenuFlyout {...props} />);
+    const menuItem1 = getByText(props.items[0].label);
+    const menuItem2 = getByText(props.items[1].label);
+    fireEvent.click(menuItem1);
+    expect(props.items[0].onClick).toHaveBeenCalledTimes(1);
+    expect(props.items[1].onClick).toHaveBeenCalledTimes(0);
+    fireEvent.click(menuItem2);
+    expect(props.items[1].onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/user-menu/user-menu.styles.js
+++ b/src/components/user-menu/user-menu.styles.js
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+import { white, black, black1a, black26 } from "../../common-styles/variables";
+import { fadeIn } from "../../common-styles/animations";
+
+export const UserMenuWrapper = styled.div`
+  position: absolute;
+  top: 25px;
+  right: 25px;
+
+  & span {
+    cursor: pointer;
+    font-weight: 500;
+    font-size: 18px;
+    text-overflow: ellipsis;
+    user-select: none;
+  }
+`;
+
+export const FlyoutWrapper = styled.div`
+  position: absolute;
+  border-radius: 4px;
+  line-height: 1;
+  border: 1px solid ${black};
+  top: 27px;
+  left: -120px;
+  width: 175px;
+  min-width: 175px;
+  height: auto;
+  background-color: ${white};
+  color: ${black};
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 5px;
+  padding-right: 5px;
+  animation: 125ms linear 0s 1 ${fadeIn};
+`;
+
+export const FlyoutMenuItem = styled.li`
+  user-select: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 32px;
+  border: 1px solid ${white};
+  transition: background-color 125ms linear;
+
+  &:hover {
+    background-color: ${black1a};
+  }
+
+  &:active {
+    background-color: ${black26};
+  }
+`;
+
+export const FlyoutItemList = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  text-align: left;
+  & ${FlyoutMenuItem} {
+    margin-bottom: 2px;
+  }
+`;

--- a/src/containers/login-page/login-page.jsx
+++ b/src/containers/login-page/login-page.jsx
@@ -24,7 +24,6 @@ const LoginPage = (props) => {
           authenticate={props.authenticate}
           authError={props.authError}
           showSignUpForm={() => setShowSignUpForm(true)}
-          showNotification={props.showNotification}
           goToDashboard={() => props.historyPush("/dashboard")}
         />
       ) : (

--- a/src/containers/navbar/navbar.jsx
+++ b/src/containers/navbar/navbar.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
+import UserMenu from "../../components/user-menu/user-menu";
 import { NavbarWrapper, NavbarBrand, SidebarToggleButton } from "./navbar.styles";
 import { faCompass } from "@fortawesome/free-regular-svg-icons";
 import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { connect } from "react-redux";
 import { toggleSidebar } from "../../store/actions/sidebar";
+import { logout } from "../../store/actions/auth";
 
 const Navbar = (props) => {
   return (
@@ -17,17 +19,22 @@ const Navbar = (props) => {
         <FontAwesomeIcon data-testid="brandIcon" icon={faCompass} fixedWidth />
         <span data-testid="brandName">Compass</span>
       </NavbarBrand>
+      {props.userInfo && <UserMenu dataTestId="userMenu" userInfo={props.userInfo} logout={props.logout}/>}
     </NavbarWrapper>
   );
 };
 
 Navbar.propTypes = {
   sidebarIsOpen: PropTypes.bool.isRequired,
-  toggleSidebar: PropTypes.func.isRequired
+  toggleSidebar: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
+  userInfo: PropTypes.object
 };
 
 export default connect((state) => ({
-  sidebarIsOpen: state.sidebar.isOpen
+  sidebarIsOpen: state.sidebar.isOpen,
+  userInfo: state.auth.user
 }), {
-  toggleSidebar
+  toggleSidebar,
+  logout
 })(Navbar);

--- a/src/containers/navbar/navbar.spec.jsx
+++ b/src/containers/navbar/navbar.spec.jsx
@@ -10,6 +10,12 @@ describe("<Navbar />", () => {
     store = mockStore({
       sidebar: {
         isOpen: false
+      },
+      auth: {
+        user: {
+          username: "testuser",
+          displayName: "testUser"
+        }
       }
     });
 
@@ -42,5 +48,20 @@ describe("<Navbar />", () => {
     const sidebarBtn = getByTestId("sidebarBtn");
     fireEvent.click(sidebarBtn);
     expect(store.dispatch).toHaveBeenCalledWith(toggleSidebar());
+  });
+
+  it("should not render the user menu until a user has signed in", () => {
+    store = mockStore({
+      sidebar: {isOpen: false},
+      auth: {}
+    });
+    const {queryByTestId} = render(<Navbar />, store);
+    expect(queryByTestId("userMenu")).toBeNull();
+  });
+
+  it("should render the user menu when a user is signed in", () => {
+    const {getByTestId, getByText} = render(<Navbar />, store);
+    expect(getByTestId("userMenu")).toBeDefined();
+    expect(getByText("testUser")).toBeDefined();
   });
 });


### PR DESCRIPTION
This PR adds:
- Add UserMenu and UserMenuFlyout components and unit tests.
- Implement UserMenu on the Navbar.
- Add Navbar unit tests to validate the UserMenu is rendering

Other PR notes:
- Removing showNotification method from LoginForm. I do not think it provides a good experience to notify user's of successful authentication, instead they will know it was successful because of being redirected to their dashboard.
- Updated unit tests for LoginForm and a typo in Tooltip tests.