### PR TITLE
Add Tooltip to SignUpForm

### DIFF
--- a/src/components/login-form/login-form.jsx
+++ b/src/components/login-form/login-form.jsx
@@ -86,8 +86,8 @@ const LoginForm = (props) => {
         <InputBox {...passwordInputProps} />
       </Form.Section>
       <Form.Actions>
-        <Button {...goToSignUpButtonProps} />
         <Button {...loginButtonProps} />
+        <Button {...goToSignUpButtonProps} />
       </Form.Actions>
     </Form>
   );

--- a/src/components/sign-up-form/sign-up-form.jsx
+++ b/src/components/sign-up-form/sign-up-form.jsx
@@ -27,6 +27,8 @@ const SignUpForm = (props) => {
 
   const _signUpDisabled = () => ((!usernameInput || !passwordInput || !confirmInput) || signUpInProgress);
 
+  const _signUpTooltip = () => _signUpDisabled() ? signUpInProgress ? "authentication in progress" : "missing required fields" : "";
+
   const _handleSignUp = async () => {
     if(confirmInput !== passwordInput)
       return setConfirmInputError("confirm and password input must be matching");
@@ -94,7 +96,8 @@ const SignUpForm = (props) => {
     startIcon: faUserPlus,
     label: "Sign Up",
     onClick: _handleSignUp,
-    dataTestId: `${dataTestId}.signUpButton`
+    dataTestId: `${dataTestId}.signUpButton`,
+    tooltip: _signUpTooltip()
   };
 
   const goToLoginButtonProps = {
@@ -120,8 +123,8 @@ const SignUpForm = (props) => {
         <InputBox {...confirmInputProps}  />
       </Form.Section>
       <Form.Actions>
-        <Button {...goToLoginButtonProps} />
         <Button {...signUpButtonProps} />
+        <Button {...goToLoginButtonProps} />
       </Form.Actions>
     </Form>
   );

--- a/src/components/sign-up-form/sign-up-form.spec.jsx
+++ b/src/components/sign-up-form/sign-up-form.spec.jsx
@@ -186,4 +186,21 @@ describe("<SignUpForm />", () => {
     fireEvent.click(button);
     expect(props.showLoginForm).toHaveBeenCalled();
   });
+
+  it("should render the tooltip for the submit button when it is disabled", () => {
+    const {getByTestId, getByText} = render(<SignUpForm {...props}/>);
+    const signUpButton = getByTestId(`${props.dataTestId}.signUpButton`);
+    expect(signUpButton).toBeDisabled();
+    fireEvent.mouseOver(signUpButton);
+    expect(getByText("missing required fields")).toBeDefined();
+  });
+
+  it("should render the tooltip for submit button when it is disabled due to pending API call", () => {
+    props.signUpInProgress = true;
+    const {getByTestId, getByText} = render(<SignUpForm {...props}/>);
+    const signUpButton = getByTestId(`${props.dataTestId}.signUpButton`);
+    expect(signUpButton).toBeDisabled();
+    fireEvent.mouseOver(signUpButton);
+    expect(getByText("authentication in progress")).toBeDefined();
+  });
 });


### PR DESCRIPTION
This PR contains:
- updated Login/Signup button placement to be more consistent.
- added Tooltip to SignUpForm when the sign up button is disabled.
- added unit tests for the new tooltip.