### PR TITLE
Add Dashboard Page - Part 3

### DIFF
--- a/src/components/check-box/check-box.jsx
+++ b/src/components/check-box/check-box.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from  "prop-types";
+import {CheckBoxWrapper, CheckBoxSquare} from "./check-box.styles";
+
+const CheckBox = (props) => {
+  const {id, dataTestId, disabled, label, checked, onChange} = props;
+  return (
+    <CheckBoxWrapper id={id} data-testid={dataTestId} disabled={disabled}>
+      {label}
+      <input data-testid={`${dataTestId}.input`} type="checkbox" checked={checked} onChange={onChange} disabled={disabled}/>
+      <CheckBoxSquare />
+    </CheckBoxWrapper>
+  );
+};
+
+CheckBox.propTypes = {
+  id: PropTypes.string,
+  dataTestId: PropTypes.string,
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  checked: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired
+};
+
+export default CheckBox;

--- a/src/components/check-box/check-box.spec.jsx
+++ b/src/components/check-box/check-box.spec.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import CheckBox from "./check-box";
+import { render } from "../../test-utils";
+import {fireEvent} from "@testing-library/react";
+
+describe("<CheckBox />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      dataTestId: "unitTestCheckBox",
+      label: "Unit Testing Checkbox",
+      checked: false,
+      onChange: jest.fn()
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<CheckBox {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the checkbox label", () => {
+    const {getByTestId, getByText} = render(<CheckBox {...props} />);
+    expect(getByTestId("unitTestCheckBox")).toBeDefined();
+    expect(getByText("Unit Testing Checkbox")).toBeDefined();
+    const checkbox = getByTestId("unitTestCheckBox.input");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("should call props.onChange when the checkbox is clicked", () => {
+    const {getByText} = render(<CheckBox {...props} />);
+    const checkbox = getByText("Unit Testing Checkbox");
+    fireEvent.click(checkbox);
+    expect(props.onChange).toHaveBeenCalled();
+  });
+
+  it("should not call props.onChange when a disabled checkbox is clicked", () => {
+    props.disabled = true;
+    const {getByText} = render(<CheckBox {...props} />);
+    const checkbox = getByText("Unit Testing Checkbox");
+    fireEvent.click(checkbox);
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/check-box/check-box.styles.js
+++ b/src/components/check-box/check-box.styles.js
@@ -1,0 +1,85 @@
+import styled, {css} from "styled-components";
+import {
+  black1a,
+  black33,
+  black66,
+  black99,
+  primaryBlue,
+  white
+} from "../../common-styles/variables";
+
+export const CheckBoxSquare = styled.span`
+  position: absolute;
+  top: 3px;
+  left: 0;
+  height: 20px;
+  width: 20px;
+  background-color: ${black1a};
+  transition: background-color 100ms linear;
+
+  &:after {
+    content: "";
+    position: absolute;
+    display: none;
+  }
+`;
+
+export const CheckBoxWrapper = styled.label`
+  display: block;
+  position: relative;
+  padding-left: 25px;
+  cursor: pointer;
+  font-size: 18px;
+  user-select: none;
+
+  & input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+  }
+  
+  &:hover input ~ ${CheckBoxSquare} {
+    background-color: ${black66};
+  }
+
+  & input:checked ~ ${CheckBoxSquare} {
+    background-color: ${primaryBlue};
+  }
+
+  & input:checked ~ ${CheckBoxSquare}:after {
+    display: block;
+  }
+
+  & ${CheckBoxSquare}:after {
+    left: 6px;
+    top: 2px;
+    width: 5px;
+    height: 10px;
+    border: solid ${white};
+    border-width: 0 3px 3px 0;
+    transform: rotate(45deg);
+  }
+
+  ${({disabled}) => disabled && css`
+  cursor: not-allowed;
+  color: ${black99};
+
+  & input {
+    cursor: not-allowed;
+  }
+
+  &:hover input ~ ${CheckBoxSquare} {
+    background-color: ${black33};
+  }
+
+  & input:checked ~ ${CheckBoxSquare}{
+    background-color: ${black33};
+  }
+
+  & ${CheckBoxSquare} {
+    background-color: ${black33};
+  }
+`}
+`;

--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -1,0 +1,88 @@
+import React, {useState} from "react";
+import PropTypes from "prop-types";
+import Table from "../table/table";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faArrowRight, faTrash, faEdit} from "@fortawesome/free-solid-svg-icons";
+import Tooltip from "../tooltip/tooltip";
+import {formatDate, getPermissionLevel} from "../../utils";
+import {ActionsWrapper, Action} from "../table/table.styles";
+
+const DashboardProjectsTable = ({projects, actions}) => {
+  const [hoverMap, setHover] = useState(projects.reduce((prev, curr) => {
+    if(curr.id)
+      return Object.assign(prev, {[curr.id]: false});
+    
+    return prev;
+  }, {}));
+
+  const _renderActions = (row) => {
+    const {deleteProject, editProject, viewProject} = actions;
+    const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
+    const rowHovered = hoverMap[row.id];
+    const adminAllowed = rowHovered && isAdmin;
+    const managerAllowed = rowHovered && (isAdmin || isManager);
+    const viewerAllowed = rowHovered && (isAdmin || isManager || isDeveloper || isViewer);
+    return (
+      <ActionsWrapper>
+        <Action data-testid="action.deleteProject" isAllowed={adminAllowed} onClick={() => adminAllowed && deleteProject(row)}>
+          <FontAwesomeIcon icon={faTrash} fixedWidth />
+          {adminAllowed && <Tooltip text={"Delete Project"} />}
+        </Action>
+        <Action data-testid="action.editProject" isAllowed={managerAllowed} onClick={() => managerAllowed && editProject(row)}>
+          <FontAwesomeIcon icon={faEdit} fixedWidth />
+          {managerAllowed && <Tooltip text={"Edit Project"} />}
+        </Action>
+        <Action data-testid="action.viewProject" isAllowed={viewerAllowed} onClick={() => viewerAllowed && viewProject(row)}>
+          <FontAwesomeIcon icon={faArrowRight} fixedWidth />
+          {viewerAllowed && <Tooltip text={"View Project"} />}
+        </Action>
+      </ActionsWrapper>
+    );
+  };
+
+  const tableProps = {
+    dataTestId: "dashboardProjects",
+    headers: [{
+      label: "Name",
+      keyName: "name"
+    }, {
+      label: "Unique ID",
+      keyName: "id"
+    }, {
+      label: "Visibility",
+      keyName: "isPrivate",
+      format: (isPrivate) => isPrivate ? "Private" : "Public"
+    }, {
+      label: "Permission Level",
+      keyName: "roles",
+      format: (roles) => getPermissionLevel(roles)
+    },{
+      label: "Created On",
+      keyName: "createdOn",
+      format: (timestamp) => formatDate(timestamp)
+    }, {
+      label: "Actions",
+      renderActions: _renderActions
+    }],
+    rows: projects,
+    rowProps: (row) => ({
+      onMouseOver: () => setHover({...hoverMap, [row.id]: true}),
+      onMouseLeave: () => setHover({...hoverMap, [row.id]: false})
+    })
+  };
+
+  return (
+    <Table {...tableProps} />
+  );
+};
+
+DashboardProjectsTable.propTypes = {
+  projects: PropTypes.array.isRequired,
+  actions: PropTypes.shape({
+    deleteProject: PropTypes.func.isRequired,
+    editProject: PropTypes.func.isRequired,
+    viewProject: PropTypes.func.isRequired
+  }).isRequired
+};
+
+export default DashboardProjectsTable;

--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -16,7 +16,7 @@ const DashboardProjectsTable = ({projects, actions}) => {
   }, {}));
 
   const _renderActions = (row) => {
-    const {deleteProject, editProject, viewProject} = actions;
+    const {deleteProject, updateProject, viewProject} = actions;
     const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
     const rowHovered = hoverMap[row.id];
     const adminAllowed = rowHovered && isAdmin;
@@ -28,7 +28,7 @@ const DashboardProjectsTable = ({projects, actions}) => {
           <FontAwesomeIcon icon={faTrash} fixedWidth />
           {adminAllowed && <Tooltip text={"Delete Project"} />}
         </Action>
-        <Action data-testid="action.editProject" isAllowed={managerAllowed} onClick={() => managerAllowed && editProject(row)}>
+        <Action data-testid="action.editProject" isAllowed={managerAllowed} onClick={() => managerAllowed && updateProject(row)}>
           <FontAwesomeIcon icon={faEdit} fixedWidth />
           {managerAllowed && <Tooltip text={"Edit Project"} />}
         </Action>
@@ -80,7 +80,7 @@ DashboardProjectsTable.propTypes = {
   projects: PropTypes.array.isRequired,
   actions: PropTypes.shape({
     deleteProject: PropTypes.func.isRequired,
-    editProject: PropTypes.func.isRequired,
+    updateProject: PropTypes.func.isRequired,
     viewProject: PropTypes.func.isRequired
   }).isRequired
 };

--- a/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
@@ -27,7 +27,7 @@ describe("<DashboardProjectsTable />", () => {
       }],
       actions: {
         deleteProject: jest.fn(),
-        editProject: jest.fn(),
+        updateProject: jest.fn(),
         viewProject: jest.fn()
       }
     };

--- a/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
@@ -1,0 +1,101 @@
+import React from "react";
+import DashboardProjectsTable from "./dashboard-projects-table";
+import { render } from "../../test-utils";
+import {fireEvent} from "@testing-library/react";
+
+describe("<DashboardProjectsTable />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      projects: [{
+        id: "test-id-1",
+        name: "Test Project 1",
+        isPrivate: false,
+        roles: {
+          isAdmin: true
+        },
+        createdOn: "2020-07-13T17:59:52.639Z"
+      },{
+        id: "test-id-2",
+        name: "Test Project 2",
+        isPrivate: true,
+        roles: {
+          isDeveloper: true,
+          isViewer: true
+        },
+        createdOn: "2020-07-14T17:59:52.639Z"
+      }],
+      actions: {
+        deleteProject: jest.fn(),
+        editProject: jest.fn(),
+        viewProject: jest.fn()
+      }
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<DashboardProjectsTable {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the expected headers", () => {
+    const {getByTestId, getByText} = render(<DashboardProjectsTable {...props}/>);
+    expect(getByTestId("dashboardProjects")).toBeDefined();
+    expect(getByTestId("dashboardProjects.table")).toBeDefined();
+    expect(getByTestId("dashboardProjects.tableHead")).toBeDefined();
+    expect(getByText("Name")).toBeDefined();
+    expect(getByText("Unique ID")).toBeDefined();
+    expect(getByText("Visibility")).toBeDefined();
+    expect(getByText("Permission Level")).toBeDefined();
+    expect(getByText("Created On")).toBeDefined();
+    expect(getByText("Actions")).toBeDefined();
+  });
+
+  it("should render the project data for each header", () => {
+    const {getByTestId, getByText} = render(<DashboardProjectsTable {...props} />);
+    expect(getByTestId("dashboardProjects.tableBody")).toBeDefined();
+    // Row 1 should be-
+    expect(getByText("Test Project 1")).toBeDefined();
+    expect(getByText("test-id-1")).toBeDefined();;
+    expect(getByText("Public")).toBeDefined();
+    expect(getByText("Admin")).toBeDefined();
+    expect(getByText("Jul 13, 2020")).toBeDefined();
+
+    // Row 2 should be-
+    expect(getByText("Test Project 2")).toBeDefined();
+    expect(getByText("test-id-2")).toBeDefined();
+    expect(getByText("Private")).toBeDefined();
+    expect(getByText("Developer")).toBeDefined();
+    expect(getByText("Jul 14, 2020")).toBeDefined();
+  });
+
+  it("should render the action buttons for each row", () => {
+    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    expect(getAllByTestId("action.deleteProject")).toHaveLength(2);
+    expect(getAllByTestId("action.editProject")).toHaveLength(2);
+    expect(getAllByTestId("action.viewProject")).toHaveLength(2);
+  });
+
+  it("should not call an action method if clicked when the row is not hovered", () => {
+    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const deleteAction = getAllByTestId("action.deleteProject")[0];
+    fireEvent.click(deleteAction);
+    expect(props.actions.deleteProject).not.toHaveBeenCalled();
+  });
+
+  it("should not call an action method if clicked with insufficient permissions", () => {
+    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const deleteAction = getAllByTestId("action.deleteProject")[1];
+    fireEvent.mouseOver(deleteAction);
+    fireEvent.click(deleteAction);
+    expect(props.actions.deleteProject).not.toHaveBeenCalled();
+  });
+
+  it("should call an action method if clicked with sufficient permissions", () => {
+    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const deleteAction = getAllByTestId("action.deleteProject")[0];
+    fireEvent.mouseOver(deleteAction);
+    fireEvent.click(deleteAction);
+    expect(props.actions.deleteProject).toHaveBeenCalledWith(props.projects[0]);
+  });
+});

--- a/src/components/delete-modal/delete-modal.jsx
+++ b/src/components/delete-modal/delete-modal.jsx
@@ -1,0 +1,121 @@
+import React, {useState} from "react";
+import PropTypes from "prop-types";
+import Modal from "../modal/modal";
+import InputBox from "../input-box/input-box";
+import CheckBox from "../check-box/check-box";
+import {faTrash} from "@fortawesome/free-solid-svg-icons";
+import {MessageSection, InputSection} from "./delete-modal.styles";
+
+const DeleteModal = (props) => {
+  const {
+    dataTestId,
+    headerText,
+    bodyText,
+    onClose,
+    onSubmit,
+    resource,
+    expectedInput,
+    inputProps,
+    refreshDashboard
+  } = props;
+  const [confirmInput, setConfirmInput] = useState(undefined);
+
+  const _submitDisabled = () => confirmInput !== expectedInput;
+
+  const _onSubmit = async() => {
+    const response = await onSubmit(resource.id, confirmInput);
+    if(response.error)
+      return;
+    
+    onClose();
+    if(refreshDashboard)
+      refreshDashboard();
+  };
+
+  const modalProps = {
+    onClose,
+    onSubmit: _onSubmit,
+    submitDisabled: _submitDisabled(),
+    submitTooltip: _submitDisabled() ? "missing required input" : "",
+    small: true,
+    header: {
+      startIcon: faTrash,
+      text: headerText || "Confirm Delete"
+    },
+    dataTestId,
+    danger: true
+  };
+
+  const stringInputProps = {
+    id: "confirm-string-input",
+    dataTestId: "confirmStringInput",
+    label: (inputProps && inputProps.label) || "Confirm Input",
+    placeholder: (inputProps && inputProps.placeholder) || "Enter the required value",
+    value: confirmInput || "",
+    isRequired: true,
+    onChange: (value) => setConfirmInput(value)
+  };
+
+  const boolInputProps = {
+    id: "confirm-bool-input",
+    dataTestId: "confirmBoolInput",
+    label: "Delete this Resource",
+    checked: confirmInput || false,
+    onChange: () => setConfirmInput(!confirmInput)
+  };
+
+  const _renderInputSection = () => {
+    if(typeof expectedInput === "string"){
+      return (
+        <InputSection data-testid={`${dataTestId}.stringInputSection`}>
+          <div>Enter <span>{expectedInput}</span>  below to proceed.</div>
+          <InputBox {...stringInputProps} />
+        </InputSection>
+      );
+    }
+
+    return (
+      <InputSection data-testid={`${dataTestId}.inputSection`}>
+          <div>Check the box below to proceed.</div>
+          <CheckBox {...boolInputProps} />
+      </InputSection>
+    );
+  };
+
+  const _renderMessageSection = () => (
+    <MessageSection data-testid={`${dataTestId}.messageSection`}>
+      <h3>Are you sure?</h3>
+      <h3>Once a resource has been deleted it can not be recovered.</h3>
+      {bodyText && <div>{bodyText}</div>}
+    </MessageSection>
+  );
+
+  return (
+    <Modal {...modalProps}>
+      {_renderMessageSection()}
+      {_renderInputSection()}
+    </Modal>
+  );
+};
+
+DeleteModal.propTypes = {
+  dataTestId: PropTypes.string,
+  headerText: PropTypes.string,
+  bodyText: PropTypes.string,
+  inputProps: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    placeholder: PropTypes.string.isRequired
+  }),
+  refreshDashboard: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  resource: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  }).isRequired,
+  expectedInput: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool
+  ]).isRequired
+};
+
+export default DeleteModal;

--- a/src/components/delete-modal/delete-modal.spec.jsx
+++ b/src/components/delete-modal/delete-modal.spec.jsx
@@ -1,0 +1,155 @@
+import React from "react";
+import DeleteModal from "./delete-modal";
+import { render } from "../../test-utils";
+import {fireEvent, waitFor} from "@testing-library/react";
+
+describe("<DeleteModal />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      dataTestId: "unitTestDeleteModal",
+      onClose: jest.fn(),
+      onSubmit: jest.fn().mockReturnValue({}),
+      resource: {
+        id: "unitTestId"
+      },
+      expectedInput: "some expected value"
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<DeleteModal {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the headerText if provided", () => {
+    props.headerText = "Unit Test Header";
+    const {getByText} = render(<DeleteModal {...props} />);
+    expect(getByText("Unit Test Header")).toBeDefined();
+  });
+
+  it("should render a default header if headerText is not provided", () => {
+    const {getByTextId, getByText} = render(<DeleteModal {...props} />);
+    expect(getByText("Confirm Delete")).toBeDefined();
+  });
+
+  it("should disable the delete button by default", () => {
+    const {getByTestId} = render(<DeleteModal {...props} />);
+    expect(getByTestId("unitTestDeleteModal.actions.primaryButton")).toBeDisabled();
+  });
+
+  // it("should render a tooltip if the delete button is disabled", () => {
+  //   const {queryByText} = render(<DeleteModal {...props}/>);
+  //   expect(queryByText("missing required input")).toBeDefined();
+
+  //   //TODO: Check that it does not render once submit is enabled.
+  // });
+
+  it("should render a delete button instead of submit", () => {
+    const {queryByText} = render(<DeleteModal {...props} />);
+    expect(queryByText("Delete")).toBeDefined();
+    expect(queryByText("Submit")).toBeNull();
+  });
+
+  it("should render the message section with a default warning message", () => {
+    const {getByTestId, getByText} = render(<DeleteModal {...props} />);
+    expect(getByTestId("unitTestDeleteModal.messageSection")).toBeDefined();
+    expect(getByText("Are you sure?")).toBeDefined();
+    expect(getByText("Once a resource has been deleted it can not be recovered.")).toBeDefined();
+  });
+
+  it("should render the bodyText if provided", () => {
+    props.bodyText = "unit testing body text";
+    const {getByText} = render(<DeleteModal {...props} />);
+    expect(getByText("unit testing body text")).toBeDefined();
+  });
+
+  it("should render an InputBox section if the expectedInput is a string", () => {
+    const {getByTestId, getByPlaceholderText, getByLabelText} = render(<DeleteModal {...props}/>);
+    expect(getByTestId("unitTestDeleteModal.stringInputSection")).toBeDefined();
+    expect("Enter some expected value below to proceed.");
+    expect(getByTestId("confirmStringInput")).toBeDefined();
+    const input = getByTestId("confirmStringInput.input");
+    expect(input).toBeDefined();
+
+    // Expect the default label / placeholder if one is not provided.
+    fireEvent.focus(input);
+    expect(getByLabelText("Confirm Input")).toBeDefined();
+    expect(getByPlaceholderText("Enter the required value")).toBeDefined();
+  });
+
+  it("should render an InputBox with optional label/placeholder for input", () => {
+    props.inputProps = {
+      label: "test label",
+      placeholder: "test placeholder"
+    };
+    const {getByTestId, getByPlaceholderText, getByLabelText} = render(<DeleteModal {...props}/>);
+    const input = getByTestId("confirmStringInput.input");
+    expect(input).toBeDefined();
+    fireEvent.focus(input);
+    expect(getByLabelText("test label")).toBeDefined();
+    expect(getByPlaceholderText("test placeholder")).toBeDefined();
+  });
+
+  it("should enable the delete button if input matches expectedInput", () => {
+    const {getByTestId} = render(<DeleteModal {...props}/>);
+    const input = getByTestId("confirmStringInput.input");
+    const button = getByTestId("unitTestDeleteModal.actions.primaryButton");
+    expect(button).toBeDisabled();
+    fireEvent.change(input, {
+      target: {
+        value: "some expected value"
+      }
+    });
+    expect(button).toBeEnabled();
+  });
+
+  it("should render a CheckBox input if expectedInput is non-string", () => {
+    props.expectedInput = true;
+    const {getByTestId, getByText} = render(<DeleteModal {...props} />);
+    expect(getByTestId("unitTestDeleteModal.inputSection")).toBeDefined();
+    expect("Check the box below to proceed.");
+    expect(getByTestId("confirmBoolInput")).toBeDefined();
+    const input = getByTestId("confirmBoolInput.input");
+    expect(input).toBeDefined();
+    expect(getByText("Delete this Resource")).toBeDefined();
+  });
+
+  it("should enable the delete button if the checkbox is checked", () => {
+    props.expectedInput = true;
+    const {getByTestId} = render(<DeleteModal {...props}/>);
+    const input = getByTestId("confirmBoolInput.input");
+    const button = getByTestId("unitTestDeleteModal.actions.primaryButton");
+    expect(button).toBeDisabled();
+    fireEvent.click(input);
+    expect(button).toBeEnabled();
+  });
+
+  //TODO: API Error handling is weak in this component. Add tests for that once you improve it...right now it just sinks the error.
+  it("should call onSubmit once the delete button has been clicked", async() => {
+    props.expectedInput = true;
+    const {getByTestId} = render(<DeleteModal {...props}/>);
+    const input = getByTestId("confirmBoolInput.input");
+    const button = getByTestId("unitTestDeleteModal.actions.primaryButton");
+    fireEvent.click(input);
+    fireEvent.click(button);
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledWith(props.resource.id, true));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("should call refreshDashboard, if provided, after successful onSubmit", async() => {
+    props.refreshDashboard = jest.fn();
+    const {getByTestId} = render(<DeleteModal {...props}/>);
+    const input = getByTestId("confirmStringInput.input");
+    const button = getByTestId("unitTestDeleteModal.actions.primaryButton");
+    fireEvent.change(input, {
+      target: {
+        value: props.expectedInput
+      }
+    });
+    fireEvent.click(button);
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledWith(props.resource.id, props.expectedInput));
+    expect(props.onClose).toHaveBeenCalled();
+    expect(props.refreshDashboard).toHaveBeenCalled();
+  });
+});

--- a/src/components/delete-modal/delete-modal.spec.jsx
+++ b/src/components/delete-modal/delete-modal.spec.jsx
@@ -38,13 +38,6 @@ describe("<DeleteModal />", () => {
     expect(getByTestId("unitTestDeleteModal.actions.primaryButton")).toBeDisabled();
   });
 
-  // it("should render a tooltip if the delete button is disabled", () => {
-  //   const {queryByText} = render(<DeleteModal {...props}/>);
-  //   expect(queryByText("missing required input")).toBeDefined();
-
-  //   //TODO: Check that it does not render once submit is enabled.
-  // });
-
   it("should render a delete button instead of submit", () => {
     const {queryByText} = render(<DeleteModal {...props} />);
     expect(queryByText("Delete")).toBeDefined();
@@ -117,12 +110,14 @@ describe("<DeleteModal />", () => {
 
   it("should enable the delete button if the checkbox is checked", () => {
     props.expectedInput = true;
-    const {getByTestId} = render(<DeleteModal {...props}/>);
+    const {getByTestId, queryByText} = render(<DeleteModal {...props}/>);
     const input = getByTestId("confirmBoolInput.input");
     const button = getByTestId("unitTestDeleteModal.actions.primaryButton");
     expect(button).toBeDisabled();
+    expect(queryByText("missing required input")).toBeDefined();
     fireEvent.click(input);
     expect(button).toBeEnabled();
+    expect(queryByText("missing required input")).toBeNull();
   });
 
   //TODO: API Error handling is weak in this component. Add tests for that once you improve it...right now it just sinks the error.

--- a/src/components/delete-modal/delete-modal.styles.js
+++ b/src/components/delete-modal/delete-modal.styles.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import {InputBoxWrapper} from "../input-box/input-box.styles";
+import {CheckBoxWrapper} from "../check-box/check-box.styles";
+
+export const MessageSection = styled.div`
+  & h3:first-of-type {
+    margin-top: 20px;
+    margin-bottom: 0;
+  }
+
+  & h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+  }
+
+  & div {
+    margin-bottom: 15px;
+  }
+`;
+
+export const InputSection = styled.div`
+  & > div > span {
+    font-weight: bold;
+  }
+
+  & ${InputBoxWrapper} {
+    margin-top: 15px;
+    & span {
+      font-weight: normal;
+    }
+  }
+
+  & ${CheckBoxWrapper} {
+    margin-top: 15px;
+  }
+`;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -51,9 +51,10 @@ const Modal = (props) => {
             small
             onClick={props.onSubmit}
             disabled={props.submitDisabled}
-            label="Submit"
+            label={props.danger ? "Delete" : "Submit"}
             dataTestId={`${dataTestId}.actions.primaryButton`}
             tooltip={props.submitTooltip}
+            danger={props.danger}
           />
           <Button
             secondary
@@ -80,7 +81,8 @@ Modal.propTypes = {
     endIcon: PropTypes.object
   }),
   centerHeader: PropTypes.bool,
-  dataTestId: PropTypes.string
+  dataTestId: PropTypes.string,
+  danger: PropTypes.bool
 };
 
 export default Modal;

--- a/src/components/modal/modal.spec.jsx
+++ b/src/components/modal/modal.spec.jsx
@@ -87,4 +87,10 @@ describe("<Modal />", () => {
     const {getByText} = render(<Modal {...props}/>);
     expect(getByText(props.submitTooltip)).toBeDefined();
   });
+
+  it("should render a delete button if the modal has the danger property", () => {
+    props.danger = true;
+    const {getByText} = render(<Modal {...props} />);
+    expect(getByText("Delete")).toBeDefined();
+  });
 });

--- a/src/components/project-modal/project-modal.spec.jsx
+++ b/src/components/project-modal/project-modal.spec.jsx
@@ -1,14 +1,14 @@
 import React from "react";
-import NewProjectModal from "./new-project-modal";
+import ProjectModal from "./project-modal";
 import { render } from "../../test-utils";
 import { fireEvent, waitFor } from "@testing-library/react";
 
-describe("<NewProjectModal />", () => {
+describe("<ProjectModal />", () => {
   let props;
   beforeEach(() => {
     props = {
       onClose: jest.fn(),
-      createProject: jest.fn(),
+      onSubmit: jest.fn(),
       showNotification: jest.fn(),
       requestInProgress: false,
       refreshDashboard: jest.fn()
@@ -16,25 +16,25 @@ describe("<NewProjectModal />", () => {
   });
 
   it("should mount the component", () => {
-    const component = render(<NewProjectModal {...props}/>);
+    const component = render(<ProjectModal {...props}/>);
     expect(component).toBeDefined();
   });
 
   it("should disable the submit button by default", () => {
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const {getByTestId} = render(<ProjectModal {...props}/>);
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     expect(submitButton).toBeDisabled();
   });
 
   it("should render the expected inputs", () => {
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
     expect(getByTestId("nameInput")).toBeDefined();
     expect(getByTestId("descriptionInput")).toBeDefined();
     expect(getByTestId("isPrivateInput")).toBeDefined();
   });
 
   it("should set isPrivate to false by default", () => {
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
     const isPublicOption = getByTestId("isPrivateInput.option.0");
     const isPrivateOption = getByTestId("isPrivateInput.option.1");
     expect(isPublicOption).toBeChecked();
@@ -42,28 +42,28 @@ describe("<NewProjectModal />", () => {
   });
 
   it("should enable the submit button if all required input is present without input errors", () => {
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
     const nameInput = getByTestId("nameInput.input");
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     fireEvent.change(nameInput, {target: {value: "some name"}});
     expect(submitButton).toBeEnabled();
   });
 
   it("should disable the submit button if an API call is in progress", () => {
     props.requestInProgress = true;
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
     const nameInput = getByTestId("nameInput.input");
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     fireEvent.change(nameInput, {target: {value: "some name"}});
     expect(submitButton).toBeDisabled();
   });
 
 
   it("should disable the submit button if there is an input error", async() => {
-    props.createProject.mockReturnValueOnce({error: "name input error"});
-    const {getByTestId, queryByText} = render(<NewProjectModal {...props}/>);
+    props.onSubmit.mockReturnValueOnce({error: "name input error"});
+    const {getByTestId, queryByText} = render(<ProjectModal {...props}/>);
     const nameInput = getByTestId("nameInput.input");
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     fireEvent.change(nameInput, {target: {value: "some name"}});
     expect(queryByText("something went wrong")).toBeNull();
     fireEvent.click(submitButton);
@@ -73,49 +73,83 @@ describe("<NewProjectModal />", () => {
 
   it("should render the tooltip for submit button when it is disabled due to pending API call", () => {
     props.requestInProgress = true;
-    const {getByTestId, getByText} = render(<NewProjectModal {...props}/>);
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const {getByTestId, getByText} = render(<ProjectModal {...props}/>);
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     expect(submitButton).toBeDisabled();
     fireEvent.mouseOver(submitButton);
     expect(getByText("request in progress")).toBeDefined();
   });
 
   it("should render the tooltip for submit button when it is disabled due to missing input", () => {
-    const {getByTestId, getByText} = render(<NewProjectModal {...props}/>);
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const {getByTestId, getByText} = render(<ProjectModal {...props}/>);
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     expect(submitButton).toBeDisabled();
     fireEvent.mouseOver(submitButton);
     expect(getByText("missing required fields")).toBeDefined();
   });
 
-  it("should call the createProject method if submit is clicked and there is no validation error", async() => {
+  it("should call the onSubmit method if submit is clicked and there is no validation error", async() => {
     const name = "some project name";
     const description = "some description";
-    props.createProject.mockReturnValueOnce({});
-    const {getByTestId, getByText} = render(<NewProjectModal {...props}/>);
+    props.onSubmit.mockReturnValueOnce({});
+    const {getByTestId, getByText} = render(<ProjectModal {...props}/>);
     const nameInput = getByTestId("nameInput.input");
     const descriptionInput = getByTestId("descriptionInput.input");
     const isPrivateInput = getByText("Private");
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     fireEvent.change(nameInput, {target: {value: name}});
     fireEvent.change(descriptionInput, {target: {value: description}});
     fireEvent.click(isPrivateInput);
     fireEvent.click(submitButton);
-    await waitFor(() => expect(props.createProject).toHaveBeenCalledTimes(1));
-    expect(props.createProject).toHaveBeenCalledWith(name, description, true);
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledTimes(1));
+    expect(props.onSubmit).toHaveBeenCalledWith(name, description, true);
   });
 
   it("should call onClose, refreshDashboard, and showNotification methods after a successful API call", async() => {
     const expectedMessage = "unit test success message";
-    props.createProject.mockReturnValueOnce({message: expectedMessage});
-    const {getByTestId} = render(<NewProjectModal {...props}/>);
+    props.onSubmit.mockReturnValueOnce({message: expectedMessage});
+    const {getByTestId} = render(<ProjectModal {...props}/>);
     const nameInput = getByTestId("nameInput.input");
-    const submitButton = getByTestId("newProjectModal.actions.primaryButton");
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
     fireEvent.change(nameInput, {target: {value: "some project name"}});
     fireEvent.click(submitButton);
-    await waitFor(() => expect(props.createProject).toHaveBeenCalled());
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
     expect(props.onClose).toHaveBeenCalledTimes(1);
     expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(props.showNotification).toHaveBeenCalledWith(expectedMessage, "info", true);
+  });
+
+  it("should populate name, description, and isPrivate if editing a project", () => {
+    props.project = {
+      id: "testId",
+      name: "test project",
+      description: "this is a test.",
+      isPrivate: true
+    };
+    const {getByTestId, getByText} = render(<ProjectModal {...props} />);
+    expect(getByText("Edit Project")).toBeDefined();
+    const nameInput = getByTestId("nameInput.input");
+    const descriptionInput = getByTestId("descriptionInput.input");
+    const isPublic = getByTestId("isPrivateInput.option.0");
+    const isPrivate = getByTestId("isPrivateInput.option.1");
+    expect(nameInput).toHaveValue(props.project.name);
+    expect(descriptionInput).toHaveValue(props.project.description);
+    expect(isPublic).not.toBeChecked();
+    expect(isPrivate).toBeChecked();
+  });
+
+  it("should pass project.id to the onSubmit method if editing a project", async() => {
+    props.project = {
+      id: "testId",
+      name: "test project",
+      description: "this is a test.",
+      isPrivate: true
+    };
+    props.onSubmit.mockReturnValueOnce({});
+    const {getByTestId} = render(<ProjectModal {...props} />);
+    const submitButton = getByTestId("projectModal.actions.primaryButton");
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
+    expect(props.onSubmit).toHaveBeenCalledWith("testId", "test project", "this is a test.", true);
   });
 });

--- a/src/components/radio-group/radio-group.styles.js
+++ b/src/components/radio-group/radio-group.styles.js
@@ -37,6 +37,8 @@ export const RadioContainer = styled.label`
     position: absolute;
     opacity: 0;
     cursor: pointer;
+    height: 0;
+    width: 0;
   }
 
   &:hover input ~ ${RadioCircle} {

--- a/src/components/table/table.jsx
+++ b/src/components/table/table.jsx
@@ -1,0 +1,102 @@
+import React, {useState} from "react";
+import PropTypes from "prop-types";
+import {TableWrapper, ActionsWrapper, Action} from "./table.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faArrowRight, faTrash, faEdit} from "@fortawesome/free-solid-svg-icons";
+import Tooltip from "../tooltip/tooltip";
+
+const Table = (props) => {
+  const {headers, rows} = props;
+  const [hoverMap, setHover] = useState(rows.reduce((prev, curr) => {
+    if(curr.id)
+      return Object.assign(prev, {[curr.id]: false});
+    
+    return prev;
+  }, {}));
+
+  const _renderHeaders = () => (
+    <thead>
+      <tr>
+        {headers && headers.map((header, index) => (
+          <th key={index}>{header.label}</th>
+        ))}
+      </tr>
+    </thead>
+  );
+
+  const _renderProjectActions = (row) => {
+    const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
+    const rowHovered = hoverMap[row.id];
+    const adminAllowed = rowHovered && isAdmin;
+    const managerAllowed = rowHovered && (isAdmin || isManager);
+    const viewerAllowed = rowHovered && (isAdmin || isManager || isDeveloper || isViewer);
+    return (
+      <ActionsWrapper>
+        <Action isAllowed={adminAllowed}>
+          <FontAwesomeIcon icon={faTrash} fixedWidth />
+          {adminAllowed && <Tooltip text={"Delete Project"} />}
+        </Action>
+        <Action isAllowed={managerAllowed}>
+          <FontAwesomeIcon icon={faEdit} fixedWidth />
+          {managerAllowed && <Tooltip text={"Edit Project"} />}
+        </Action>
+        <Action isAllowed={viewerAllowed}>
+          <FontAwesomeIcon icon={faArrowRight} fixedWidth />
+          {viewerAllowed && <Tooltip text={"View Project"} />}
+        </Action>
+      </ActionsWrapper>
+    );
+  };
+
+  const _renderCell = (row, header) => {
+    if(header.keyName === "projectActions")
+      return _renderProjectActions(row);
+
+    //TODO: Do this eventually, once we get to Task table development.
+    // if(header.keyName === "taskActions")
+    //   return _renderTaskActions();
+
+    const cellData = row[header.keyName];
+    if(typeof cellData === "undefined")
+      return;
+    
+    if(header.format)
+      return header.format(cellData, row);
+    
+    return cellData.toString();
+  };
+
+  const _renderBody = () => (
+    <tbody>
+      {rows && rows.map((row, index) => {
+        return (
+          <tr key={index} onMouseOver={() => setHover({...hoverMap, [row.id]: true})} onMouseLeave={() => setHover({...hoverMap, [row.id]: false})}>
+            {headers && headers.map((header, index) => {
+              return (
+                <td key={index}>
+                  {_renderCell(row, header)}
+                </td>
+              );
+            })}
+          </tr>
+        );
+      })}
+    </tbody>
+  );
+
+  return (
+    <TableWrapper>
+      <table>
+        {_renderHeaders()}
+        {_renderBody()}
+      </table>
+    </TableWrapper>
+  );
+};
+
+Table.propTypes = {
+  headers: PropTypes.array.isRequired,
+  rows: PropTypes.array.isRequired
+};
+
+export default Table;

--- a/src/components/table/table.spec.jsx
+++ b/src/components/table/table.spec.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+import Table from "./table";
+import { render } from "../../test-utils";
+import {fireEvent} from "@testing-library/react";
+
+describe("<Table />", () => {
+  let props;
+  let _onClick = jest.fn();
+  beforeEach(() => {
+    props = {
+      dataTestId: "unitTestingTable",
+      headers: [{
+        label: "Label 1",
+        keyName: "key1"
+      },{
+        label: "Label 2",
+        keyName: "key2"
+      },{
+        label: "Label 3",
+        keyName: "key3"
+      }],
+      rows: [{
+        key1: "first value one",
+        key2: "first value two",
+        key3: "first value three",
+        key4: "first value four"
+      }, {
+        key1: "second value one",
+        key2: "second value two",
+        key3: "second value three",
+        key4: "second value four"
+      }],
+      rowProps: jest.fn().mockReturnValue({
+        onClick: _onClick
+      })
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<Table {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the table head with expected headers", () => {
+    const {getByTestId, getByText} = render(<Table {...props} />);
+    expect(getByTestId("unitTestingTable")).toBeDefined();
+    expect(getByTestId("unitTestingTable.table")).toBeDefined();
+    expect(getByTestId("unitTestingTable.tableHead")).toBeDefined();
+    expect(getByText("Label 1")).toBeDefined();
+    expect(getByText("Label 2")).toBeDefined();
+    expect(getByText("Label 3")).toBeDefined();
+  });
+
+  it("should render the table body with expected data", () => {
+    const {getByTestId, queryByText} = render(<Table {...props} />);
+    expect(getByTestId("unitTestingTable.tableBody")).toBeDefined();
+    expect(queryByText("first value one")).toBeDefined();
+    expect(queryByText("first value two")).toBeDefined();
+    expect(queryByText("first value three")).toBeDefined();
+    expect(queryByText("first value four")).toBeNull();
+    expect(queryByText("second value one")).toBeDefined();
+    expect(queryByText("second value two")).toBeDefined();
+    expect(queryByText("second value three")).toBeDefined();
+    expect(queryByText("second value four")).toBeNull();
+  });
+
+  it("should apply optional rowProps to each row", () => {
+    const {getByText} = render(<Table {...props} />);
+    expect(props.rowProps).toHaveBeenCalledTimes(2); // we have 2 rows setup in props.
+    const rowCell = getByText("first value one");
+    fireEvent.click(rowCell);
+    expect(_onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should format cell data based on the headers format method", () => {
+    props.headers[0].format = jest.fn().mockReturnValue("formatted 1").mockReturnValueOnce("formatted 2");
+    const {getByText} = render(<Table {...props} />);
+    expect(props.headers[0].format).toHaveBeenCalledTimes(2);
+    expect(getByText("formatted 1")).toBeDefined();
+    expect(getByText("formatted 2")).toBeDefined();
+  });
+
+  it("should call renderActions if it is provided to a header", () => {
+    props.headers[0].renderActions = jest.fn().mockReturnValue("rendered via actions method");
+    const {getAllByText} = render(<Table {...props} />);
+    expect(props.headers[0].renderActions).toHaveBeenCalledTimes(2);
+    expect(getAllByText("rendered via actions method")).toHaveLength(2);
+  });
+});

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -21,6 +21,7 @@ export const Action = styled.div`
   `}
 
   &:hover ${TooltipWrapper} {
+    font-size: 16px;
     visibility: visible;
     opacity: 1;
     left: -50px;

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -1,0 +1,73 @@
+import styled, {css} from "styled-components";
+import {
+  black,
+  black80,
+  black33,
+  tertiaryBlue26
+} from "../../common-styles/variables";
+import {TooltipWrapper} from "../tooltip/tooltip.styles";
+
+export const Action = styled.div`
+  position: relative;
+  user-select: none;
+  line-height: 0;
+  cursor: not-allowed;
+  color: ${black33};
+  transition: color 100ms linear;
+
+  ${({isAllowed}) => isAllowed && css`
+    color: ${black};
+    cursor: pointer;
+  `}
+
+  &:hover ${TooltipWrapper} {
+    visibility: visible;
+    opacity: 1;
+    left: -50px;
+    bottom: -33px;
+  }
+`;
+
+export const ActionsWrapper = styled.div`
+  display: block;
+  top: 20px;
+
+  & ${Action} {
+    display: inline-block;
+    margin-right: 10px;
+  }
+
+  & ${Action}:last-of-type {
+    margin-right: 0;
+  }
+`;
+
+export const TableWrapper = styled.div`
+  position: relative;
+
+  & table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 18px;
+
+    & th {
+      width: 10%;
+      border-bottom: 1px solid ${black};
+      text-align: left;
+    }
+
+    & tbody tr {
+      transition: background-color 100ms linear;
+    }
+
+    & tbody tr:hover {
+      background-color: ${tertiaryBlue26};
+    }
+
+    & tbody td {
+      padding-top: 20px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid ${black80};
+    }
+  }
+`;

--- a/src/components/tooltip/tooltip.styles.js
+++ b/src/components/tooltip/tooltip.styles.js
@@ -14,4 +14,5 @@ export const TooltipWrapper = styled.div`
   visibility: hidden;
   transition: opacity 200ms linear;
   z-index: 3000;
+  line-height: normal;
 `;

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -10,6 +10,8 @@ import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Button from "../../components/button/button";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import NewProjectModal from "../../components/new-project-modal/new-project-modal";
+import Table from "../../components/table/table";
+import {formatDate, getPermissionLevel} from "../../utils";
 
 const Dashboard = (props) => {
   const {
@@ -18,13 +20,40 @@ const Dashboard = (props) => {
     userInfo,
     showNotification,
     projectCreateInProgress,
-    createProject
+    createProject,
+    projects
   } = props;
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
 
   useEffect(() => {
     getDashboard();
   }, []);
+
+  const projectsTableProps = {
+    headers: [{
+      label: "Name",
+      keyName: "name"
+    }, {
+      label: "Unique ID",
+      keyName: "id"
+    }, {
+      label: "Visibility",
+      keyName: "isPrivate",
+      format: (isPrivate) => isPrivate ? "Private" : "Public"
+    }, {
+      label: "Permission Level",
+      keyName: "roles",
+      format: (roles) => getPermissionLevel(roles)
+    },{
+      label: "Created On",
+      keyName: "createdOn",
+      format: (timestamp) => formatDate(timestamp)
+    }, {
+      label: "Actions",
+      keyName: "projectActions"
+    }],
+    rows: projects
+  };
 
   return (
     <DashboardWrapper>
@@ -56,8 +85,12 @@ const Dashboard = (props) => {
               <Tabs.Header>My Stories</Tabs.Header>
             </Tabs.TabHeaders>
             <Tabs.TabPanels>
-              <Tabs.Panel>Hello, World!</Tabs.Panel>
-              <Tabs.Panel>This is some srs content.</Tabs.Panel>
+              <Tabs.Panel>
+                <Table {...projectsTableProps} />
+              </Tabs.Panel>
+              <Tabs.Panel>
+                This is some srs content.
+              </Tabs.Panel>
             </Tabs.TabPanels>
           </Tabs>
           {showNewProjectModal && (

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -5,12 +5,14 @@ import {DashboardWrapper, DashboardActionButtons} from "./dashboard.styles";
 import Tabs from "../../components/tabs/tabs";
 import {showNotification} from "../../store/actions/notification";
 import {getDashboard} from "../../store/actions/dashboard";
-import {createProject, updateProject} from "../../store/actions/project";
+import {createProject, updateProject, deleteProject} from "../../store/actions/project";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Button from "../../components/button/button";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
 import ProjectsTable from "../../components/dashboard-projects-table/dashboard-projects-table";
+import DeleteModal from "../../components/delete-modal/delete-modal";
+import {push} from "connected-react-router";
 
 const Dashboard = (props) => {
   const {
@@ -21,10 +23,13 @@ const Dashboard = (props) => {
     projectRequestInProgress,
     createProject,
     updateProject,
-    projects
+    deleteProject,
+    projects,
+    historyPush
   } = props;
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
   const [editProjectData, setEditProject] = useState({});
+  const [deleteProjectData, setDeleteProject] = useState({});
 
   useEffect(() => {
     getDashboard();
@@ -33,9 +38,9 @@ const Dashboard = (props) => {
   const projectsTableProps = {
     projects,
     actions: {
-      deleteProject: (project) => console.log(`Delete: ${project.id}`),
+      deleteProject: (project) => setDeleteProject(project),
       updateProject: (project) => setEditProject(project),
-      viewProject: (project) => console.log(`View: ${project.id}`)
+      viewProject: (project) => historyPush(`/projects/${project.id}`)
     }
   };
 
@@ -82,6 +87,7 @@ const Dashboard = (props) => {
               </Tabs.Panel>
             </Tabs.TabPanels>
           </Tabs>
+          {/* Just modals down here, nothing to see. */}
           {showNewProjectModal && (
             <ProjectModal 
               onClose={() => setShowNewProjectModal(false)}
@@ -100,6 +106,23 @@ const Dashboard = (props) => {
               project={editProjectData}
             />
           )}
+          {deleteProjectData.id && (
+            <DeleteModal
+              onClose={() => setDeleteProject({})}
+              onSubmit={deleteProject}
+              dataTestId="projectDeleteModal"
+              headerText="Delete Project"
+              bodyText={`All memberships and stories belonging to this project will be
+              deleted as well. Please proceed with caution.`}
+              resource={deleteProjectData}
+              expectedInput={deleteProjectData.name}
+              inputProps={{
+                label: "Project Name",
+                placeholder: "Enter the project's name"
+              }}
+              refreshDashboard={getDashboard}
+            />
+          )}
         </Fragment>
       )}
     </DashboardWrapper>
@@ -114,7 +137,9 @@ Dashboard.propTypes = {
   projectRequestInProgress: PropTypes.bool.isRequired,
   createProject: PropTypes.func.isRequired,
   updateProject: PropTypes.func.isRequired,
-  showNotification: PropTypes.func.isRequired
+  deleteProject: PropTypes.func.isRequired,
+  showNotification: PropTypes.func.isRequired,
+  historyPush: PropTypes.func.isRequired
 };
 
 export default connect((state) => ({
@@ -127,5 +152,7 @@ export default connect((state) => ({
   getDashboard,
   showNotification,
   createProject,
-  updateProject
+  updateProject,
+  deleteProject,
+  historyPush: push
 })(Dashboard);

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -10,8 +10,7 @@ import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Button from "../../components/button/button";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import NewProjectModal from "../../components/new-project-modal/new-project-modal";
-import Table from "../../components/table/table";
-import {formatDate, getPermissionLevel} from "../../utils";
+import ProjectsTable from "../../components/dashboard-projects-table/dashboard-projects-table";
 
 const Dashboard = (props) => {
   const {
@@ -30,29 +29,12 @@ const Dashboard = (props) => {
   }, []);
 
   const projectsTableProps = {
-    headers: [{
-      label: "Name",
-      keyName: "name"
-    }, {
-      label: "Unique ID",
-      keyName: "id"
-    }, {
-      label: "Visibility",
-      keyName: "isPrivate",
-      format: (isPrivate) => isPrivate ? "Private" : "Public"
-    }, {
-      label: "Permission Level",
-      keyName: "roles",
-      format: (roles) => getPermissionLevel(roles)
-    },{
-      label: "Created On",
-      keyName: "createdOn",
-      format: (timestamp) => formatDate(timestamp)
-    }, {
-      label: "Actions",
-      keyName: "projectActions"
-    }],
-    rows: projects
+    projects,
+    actions: {
+      deleteProject: (project) => console.log(`Delete: ${project.id}`),
+      editProject: (project) => console.log(`Edit: ${project.id}`),
+      viewProject: (project) => console.log(`View: ${project.id}`)
+    }
   };
 
   return (
@@ -86,7 +68,12 @@ const Dashboard = (props) => {
             </Tabs.TabHeaders>
             <Tabs.TabPanels>
               <Tabs.Panel>
-                <Table {...projectsTableProps} />
+                {projects.length ? (
+                  <ProjectsTable {...projectsTableProps} />
+                ) : (
+                  <div>You are not a member of any projects</div>
+                )
+                }
               </Tabs.Panel>
               <Tabs.Panel>
                 This is some srs content.

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -5,11 +5,11 @@ import {DashboardWrapper, DashboardActionButtons} from "./dashboard.styles";
 import Tabs from "../../components/tabs/tabs";
 import {showNotification} from "../../store/actions/notification";
 import {getDashboard} from "../../store/actions/dashboard";
-import {createProject} from "../../store/actions/project";
+import {createProject, updateProject} from "../../store/actions/project";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Button from "../../components/button/button";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
-import NewProjectModal from "../../components/new-project-modal/new-project-modal";
+import ProjectModal from "../../components/project-modal/project-modal";
 import ProjectsTable from "../../components/dashboard-projects-table/dashboard-projects-table";
 
 const Dashboard = (props) => {
@@ -18,11 +18,13 @@ const Dashboard = (props) => {
     isLoading,
     userInfo,
     showNotification,
-    projectCreateInProgress,
+    projectRequestInProgress,
     createProject,
+    updateProject,
     projects
   } = props;
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
+  const [editProjectData, setEditProject] = useState({});
 
   useEffect(() => {
     getDashboard();
@@ -32,7 +34,7 @@ const Dashboard = (props) => {
     projects,
     actions: {
       deleteProject: (project) => console.log(`Delete: ${project.id}`),
-      editProject: (project) => console.log(`Edit: ${project.id}`),
+      updateProject: (project) => setEditProject(project),
       viewProject: (project) => console.log(`View: ${project.id}`)
     }
   };
@@ -81,12 +83,21 @@ const Dashboard = (props) => {
             </Tabs.TabPanels>
           </Tabs>
           {showNewProjectModal && (
-            <NewProjectModal 
+            <ProjectModal 
               onClose={() => setShowNewProjectModal(false)}
-              createProject={createProject}
+              onSubmit={createProject}
               showNotification={showNotification}
-              requestInProgress={projectCreateInProgress}
+              requestInProgress={projectRequestInProgress}
               refreshDashboard={getDashboard}
+            />
+          )}
+          {editProjectData.id && (
+            <ProjectModal
+              onClose={() => setEditProject({})}
+              onSubmit={updateProject}
+              requestInProgress={projectRequestInProgress}
+              refreshDashboard={getDashboard}
+              project={editProjectData}
             />
           )}
         </Fragment>
@@ -100,8 +111,9 @@ Dashboard.propTypes = {
   projects: PropTypes.array.isRequired,
   stories: PropTypes.array.isRequired,
   getDashboard: PropTypes.func.isRequired,
-  projectCreateInProgress: PropTypes.bool.isRequired,
+  projectRequestInProgress: PropTypes.bool.isRequired,
   createProject: PropTypes.func.isRequired,
+  updateProject: PropTypes.func.isRequired,
   showNotification: PropTypes.func.isRequired
 };
 
@@ -110,9 +122,10 @@ export default connect((state) => ({
   projects: state.dashboard.projects,
   stories: state.dashboard.stories,
   userInfo: state.auth.user,
-  projectCreateInProgress: state.project.isLoading
+  projectRequestInProgress: state.project.isLoading
 }), {
   getDashboard,
   showNotification,
-  createProject
+  createProject,
+  updateProject
 })(Dashboard);

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -78,4 +78,37 @@ describe("<Dashboard />", () => {
     fireEvent.click(newProjectButton);
     expect(queryByTestId("newProjectModal.wrapper")).toBeDefined();
   });
+
+  it("should render a message is there are no projects to display", () => {
+    const {getByText} = render(<Dashboard />, store);
+    expect(getByText("You are not a member of any projects")).toBeDefined();
+  });
+
+  it("should render the projects table if there are projects to display", () => {
+    store = mockStore({
+      dashboard: {
+        isLoading: false,
+        stories: [],
+        projects: [{
+          id: "some-id",
+          name: "Test Project",
+          isPrivate: true,
+          roles: {
+            isAdmin: true
+          },
+          createdOn: new Date().toISOString()
+        }]
+      },
+      auth: {
+        user: {
+          displayName: "unitTestUser"
+        }
+      },
+      project: {
+        isLoading: false
+      }
+    });
+    const {getByTestId} = render(<Dashboard />, store);
+    expect(getByTestId("dashboardProjects")).toBeDefined();
+  });
 });

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -113,12 +113,36 @@ describe("<Dashboard />", () => {
     expect(getByTestId("dashboardProjects")).toBeDefined();
   });
 
-  it("should render the ProjectModal if the edit modal action is clicked", () => {
+  it("should render the ProjectModal if the edit project action is clicked", () => {
     const {getByTestId, queryByTestId} = render(<Dashboard />, store);
     const editButton = getByTestId("action.editProject");
     expect(queryByTestId("projectModal.wrapper")).toBeNull();
     fireEvent.mouseOver(editButton);
     fireEvent.click(editButton);
     expect(queryByTestId("projectModal.wrapper")).toBeDefined();
+  });
+
+  it("should render the DeleteModal if the delete project action is clicked", () => {
+    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
+    const deleteButton = getByTestId("action.deleteProject");
+    expect(queryByTestId("projectDeleteModal.wrapper")).toBeNull();
+    fireEvent.mouseOver(deleteButton);
+    fireEvent.click(deleteButton);
+    expect(queryByTestId("projectDeleteModal.wrapper")).toBeDefined();
+  });
+
+  it("should call the push redux action when the view project action is clicked", async() => {
+    const {getByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.getActions()).toHaveLength(2));
+    const viewButton = getByTestId("action.viewProject");
+    fireEvent.mouseOver(viewButton);
+    fireEvent.click(viewButton);
+    expect(store.getActions()[2]).toEqual({
+      type: "@@router/CALL_HISTORY_METHOD",
+      payload: {
+        method: "push",
+        args: [`/projects/${store.getState().dashboard.projects[0].id}`]
+      }
+    });
   });
 });

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -9,7 +9,16 @@ describe("<Dashboard />", () => {
     store = mockStore({
       dashboard: {
         isLoading: false,
-        projects: [],
+        projects: [{
+          id: "some-id",
+          name: "Test Project",
+          description: "",
+          isPrivate: true,
+          roles: {
+            isAdmin: true
+          },
+          createdOn: new Date().toISOString()
+        }],
         stories: []
       },
       auth: {
@@ -70,34 +79,21 @@ describe("<Dashboard />", () => {
     expect(getByText("My Stories")).toBeDefined();
   });
 
-  it("should render the NewProjectModal when the new project button is clicked", () => {
+  it("should render the ProjectModal when the new project button is clicked", () => {
     const {queryByTestId} = render(<Dashboard />, store);
     const newProjectButton = queryByTestId("dashboardNewProject");
     expect(newProjectButton).toBeDefined();
-    expect(queryByTestId("newProjectModal.wrapper")).toBeNull();
+    expect(queryByTestId("projectModal.wrapper")).toBeNull();
     fireEvent.click(newProjectButton);
-    expect(queryByTestId("newProjectModal.wrapper")).toBeDefined();
+    expect(queryByTestId("projectModal.wrapper")).toBeDefined();
   });
 
   it("should render a message is there are no projects to display", () => {
-    const {getByText} = render(<Dashboard />, store);
-    expect(getByText("You are not a member of any projects")).toBeDefined();
-  });
-
-  it("should render the projects table if there are projects to display", () => {
     store = mockStore({
       dashboard: {
         isLoading: false,
         stories: [],
-        projects: [{
-          id: "some-id",
-          name: "Test Project",
-          isPrivate: true,
-          roles: {
-            isAdmin: true
-          },
-          createdOn: new Date().toISOString()
-        }]
+        projects: []
       },
       auth: {
         user: {
@@ -108,7 +104,21 @@ describe("<Dashboard />", () => {
         isLoading: false
       }
     });
+    const {getByText} = render(<Dashboard />, store);
+    expect(getByText("You are not a member of any projects")).toBeDefined();
+  });
+
+  it("should render the projects table if there are projects to display", () => {
     const {getByTestId} = render(<Dashboard />, store);
     expect(getByTestId("dashboardProjects")).toBeDefined();
+  });
+
+  it("should render the ProjectModal if the edit modal action is clicked", () => {
+    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
+    const editButton = getByTestId("action.editProject");
+    expect(queryByTestId("projectModal.wrapper")).toBeNull();
+    fireEvent.mouseOver(editButton);
+    fireEvent.click(editButton);
+    expect(queryByTestId("projectModal.wrapper")).toBeDefined();
   });
 });

--- a/src/store/actions/project.js
+++ b/src/store/actions/project.js
@@ -29,3 +29,13 @@ export const updateProject = (id, name, description, isPrivate) => dispatch => {
     }
   });
 };
+
+export const deleteProject = (id, confirm) => dispatch => {
+  return dispatch({
+    types: [PROJECT_REQUEST_START, PROJECT_REQUEST_SUCCESS, PROJECT_REQUEST_FAILURE],
+    request: request.delete(`${apiRoute}/${id}`),
+    payload: {
+      confirm
+    }
+  });
+};

--- a/src/store/actions/project.js
+++ b/src/store/actions/project.js
@@ -17,3 +17,15 @@ export const createProject = (name, description, isPrivate) => dispatch => {
     }
   });
 };
+
+export const updateProject = (id, name, description, isPrivate) => dispatch => {
+  return dispatch({
+    types: [PROJECT_REQUEST_START, PROJECT_REQUEST_SUCCESS, PROJECT_REQUEST_FAILURE],
+    request: request.post(`${apiRoute}/${id}`),
+    payload: {
+      name,
+      description,
+      isPrivate
+    }
+  });
+};

--- a/src/store/reducers/project/project.spec.js
+++ b/src/store/reducers/project/project.spec.js
@@ -1,5 +1,5 @@
 import projectReducer from "./project";
-import {createProject} from "../../actions/project";
+import {createProject, updateProject} from "../../actions/project";
 import {mockStore} from "../../../test-utils";
 import { waitFor } from "@testing-library/react";
 
@@ -54,6 +54,15 @@ describe("Project Reducer / Actions", () => {
     expect(store.getActions()[0].type).toBe("PROJECT_REQUEST_START");
 
     // Second action is expected to be SUCCESS or FAILURE
+    const expectedTypes = ["PROJECT_REQUEST_SUCCESS", "PROJECT_REQUEST_FAILURE"];
+    expect(expectedTypes.indexOf(store.getActions()[1].type)).toBeTruthy();
+  });
+
+  it("should dispatch a redux API call to update a project", async () => {
+    store.dispatch(updateProject("someTestId", "unit test project", "", false));
+    await waitFor(() => expect(store.getActions()).toHaveLength(2));
+    expect(store.getActions()[0].type).toBe("PROJECT_REQUEST_START");
+
     const expectedTypes = ["PROJECT_REQUEST_SUCCESS", "PROJECT_REQUEST_FAILURE"];
     expect(expectedTypes.indexOf(store.getActions()[1].type)).toBeTruthy();
   });

--- a/src/store/reducers/project/project.spec.js
+++ b/src/store/reducers/project/project.spec.js
@@ -1,5 +1,5 @@
 import projectReducer from "./project";
-import {createProject, updateProject} from "../../actions/project";
+import {createProject, updateProject, deleteProject} from "../../actions/project";
 import {mockStore} from "../../../test-utils";
 import { waitFor } from "@testing-library/react";
 
@@ -60,6 +60,15 @@ describe("Project Reducer / Actions", () => {
 
   it("should dispatch a redux API call to update a project", async () => {
     store.dispatch(updateProject("someTestId", "unit test project", "", false));
+    await waitFor(() => expect(store.getActions()).toHaveLength(2));
+    expect(store.getActions()[0].type).toBe("PROJECT_REQUEST_START");
+
+    const expectedTypes = ["PROJECT_REQUEST_SUCCESS", "PROJECT_REQUEST_FAILURE"];
+    expect(expectedTypes.indexOf(store.getActions()[1].type)).toBeTruthy();
+  });
+
+  it("should dispatch a redux API call to delete a project", async () => {
+    store.dispatch(deleteProject("someTestId", "confirmInput"));
     await waitFor(() => expect(store.getActions()).toHaveLength(2));
     expect(store.getActions()[0].type).toBe("PROJECT_REQUEST_START");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,30 @@
+const monthAbbreviations = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun", 
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+];
+
+export const formatDate = (timestampString) => {
+  const timestamp = new Date(timestampString);
+  const monthName = monthAbbreviations[timestamp.getMonth()];
+  const dayNumber = timestamp.getDate();
+  const fullYear = timestamp.getFullYear();
+  return `${monthName} ${dayNumber}, ${fullYear}`;
+};
+
+export const getPermissionLevel = (roles) => {
+  const {isAdmin, isManager, isDeveloper, isViewer} = roles;
+  if(isAdmin)
+    return "Admin";
+  
+  if(isManager)
+    return "Manager";
+  
+  if(isDeveloper)
+    return "Developer";
+  
+  if(isViewer)
+    return "Viewer";
+
+  return "None";
+    
+};


### PR DESCRIPTION
This PR contains:
- updated Tooltip styles, adding a default line-height.
- added generic Table component and unit tests.
- added DashboardProjectsTable component and unit tests.
- refactored NewProjectModal into ProjectModal. A more generic modal that can be used for creating/updating projects.
- added DashboardProjectsTable and edit ProjectModal to Dashboard and unit tests.
- added updateProject redux action and test.
- added deleteProject redux action and test.
- added common utils file with generic methods for formatting data. Currently only in use in DashboardProjectsTable.
- added generic CheckBox component and unit tests.
- updated Modal component to render a Delete button, added unit test.
- added generic DeleteModal component that can be used for deleting all application resources, added unit tests.
- added project Delete/Edit/View functionality to Dashboard, added unit tests.
