### PR TITLE
Updates to Dashboard and ProjectDetails

### DIFF
--- a/src/common-styles/variables.js
+++ b/src/common-styles/variables.js
@@ -28,7 +28,9 @@ export const tertiaryBlue26 = "#114E7926";
 
 export const primaryRed = "#DC3545";
 export const secondaryRed = "#C43240";
+export const secondaryRed1a = "#C432401A";
 export const tertiaryRed = "#B82E3C";
+export const tertiaryRed26 = "#B82E3C26";
 
 export const lightGrey = "#949494";
 

--- a/src/components/button/button.styles.js
+++ b/src/components/button/button.styles.js
@@ -14,7 +14,9 @@ import {
   tertiaryBlue26,
   primaryRed,
   secondaryRed,
+  secondaryRed1a,
   tertiaryRed,
+  tertiaryRed26,
   buttonHeight,
   smallButtonHeight
 } from "../../common-styles/variables";
@@ -54,10 +56,16 @@ export const ButtonWrapper = styled.div`
       border-color: ${primaryBlue};
     `}
 
-    ${({danger}) => danger && css`
+    ${({primary, danger}) => danger && primary && css`
       color: ${white};
       background-color: ${primaryRed};
     `}
+
+    ${({secondary, danger}) => danger && secondary && css`
+      color: ${primaryRed};
+      background-color: ${white};
+      border-color: ${primaryRed};
+  `}
   }
 
   & button:hover {
@@ -72,8 +80,14 @@ export const ButtonWrapper = styled.div`
       border-color: ${secondaryBlue};
     `}
 
-    ${({danger}) => danger && css`
+    ${({primary, danger}) => danger && primary && css`
       background-color: ${secondaryRed};
+    `}
+
+    ${({secondary, danger}) => danger && secondary && css`
+      color: ${secondaryRed};
+      background-color: ${secondaryRed1a};
+      border-color: ${secondaryRed};
     `}
   }
 
@@ -89,8 +103,14 @@ export const ButtonWrapper = styled.div`
       background-color: ${tertiaryBlue26};
     `}
 
-    ${({danger}) => danger && css`
+    ${({primary, danger}) => danger && primary && css`
       background-color: ${tertiaryRed};
+    `}
+
+    ${({secondary, danger}) => danger && secondary && css`
+      color: ${tertiaryRed};
+      background-color: ${tertiaryRed26};
+      border-color: ${tertiaryRed};
     `}
   }
 

--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import PropTypes from "prop-types";
 import Table from "../table/table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {faArrowRight, faTrash, faEdit, faUserPlus} from "@fortawesome/free-solid-svg-icons";
+import {faArrowRight, faTrash, faBook, faUserPlus} from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "../tooltip/tooltip";
 import {formatDate, getPermissionLevel} from "../../utils";
 import {ActionsWrapper, Action} from "../table/table.styles";
@@ -16,11 +16,12 @@ const DashboardProjectsTable = ({projects, actions}) => {
   }, {}));
 
   const _renderActions = (row) => {
-    const {deleteProject, updateProject, addMember, viewProject} = actions;
+    const {deleteProject, addStory, addMember, viewProject} = actions;
     const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
     const rowHovered = hoverMap[row.id];
     const adminAllowed = isAdmin;
     const managerAllowed = (isAdmin || isManager);
+    const developerAllowed = (isAdmin || isManager || isDeveloper);
     const viewerAllowed = (isAdmin || isManager || isDeveloper || isViewer);
     return (
       <ActionsWrapper>
@@ -28,13 +29,13 @@ const DashboardProjectsTable = ({projects, actions}) => {
           <FontAwesomeIcon icon={faTrash} fixedWidth />
           {adminAllowed && <Tooltip text={"Delete Project"} />}
         </Action>
-        <Action data-testid="action.editProject" highlightAction={rowHovered && managerAllowed} onClick={() => managerAllowed && updateProject(row)}>
-          <FontAwesomeIcon icon={faEdit} fixedWidth />
-          {managerAllowed && <Tooltip text={"Edit Project"} />}
-        </Action>
         <Action data-testid="action.addMember" highlightAction={rowHovered && managerAllowed} onClick={() => managerAllowed && addMember(row, adminAllowed)}>
           <FontAwesomeIcon icon={faUserPlus} fixedWidth />
           {managerAllowed && <Tooltip text={"Add Member"} />}
+        </Action>
+        <Action data-testid="action.addStory" highlightAction={rowHovered && developerAllowed} onClick={() => developerAllowed && addStory(row)}>
+          <FontAwesomeIcon icon={faBook} fixedWidth />
+          {developerAllowed && <Tooltip text={"Add Story"} />}
         </Action>
         <Action data-testid="action.viewProject" highlightAction={rowHovered && viewerAllowed} onClick={() => viewerAllowed && viewProject(row)}>
           <FontAwesomeIcon icon={faArrowRight} fixedWidth />
@@ -84,7 +85,8 @@ DashboardProjectsTable.propTypes = {
   projects: PropTypes.array.isRequired,
   actions: PropTypes.shape({
     deleteProject: PropTypes.func.isRequired,
-    updateProject: PropTypes.func.isRequired,
+    addMember: PropTypes.func.isRequired,
+    addStory: PropTypes.func.isRequired,
     viewProject: PropTypes.func.isRequired
   }).isRequired
 };

--- a/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
@@ -27,7 +27,8 @@ describe("<DashboardProjectsTable />", () => {
       }],
       actions: {
         deleteProject: jest.fn(),
-        updateProject: jest.fn(),
+        addMember: jest.fn(),
+        addStory: jest.fn(),
         viewProject: jest.fn()
       }
     };
@@ -72,7 +73,7 @@ describe("<DashboardProjectsTable />", () => {
   it("should render the action buttons for each row", () => {
     const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
     expect(getAllByTestId("action.deleteProject")).toHaveLength(2);
-    expect(getAllByTestId("action.editProject")).toHaveLength(2);
+    expect(getAllByTestId("action.addStory")).toHaveLength(2);
     expect(getAllByTestId("action.addMember")).toHaveLength(2);
     expect(getAllByTestId("action.viewProject")).toHaveLength(2);
   });
@@ -94,7 +95,7 @@ describe("<DashboardProjectsTable />", () => {
   it("should render the action tooltips if they are allowed", () => {
     const {getAllByText} = render(<DashboardProjectsTable {...props}/>);
     expect(getAllByText("Delete Project")).toHaveLength(1);
-    expect(getAllByText("Edit Project")).toHaveLength(1);
+    expect(getAllByText("Add Story")).toHaveLength(2);
     expect(getAllByText("Add Member")).toHaveLength(1);
     expect(getAllByText("View Project")).toHaveLength(2);
   });

--- a/src/components/delete-modal/delete-modal.jsx
+++ b/src/components/delete-modal/delete-modal.jsx
@@ -124,7 +124,8 @@ DeleteModal.propTypes = {
   expectedInput: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool
-  ]).isRequired
+  ]).isRequired,
+  showNotification: PropTypes.func
 };
 
 export default DeleteModal;

--- a/src/components/pagination/pagination.jsx
+++ b/src/components/pagination/pagination.jsx
@@ -34,6 +34,33 @@ const Pagination = ({page, totalPages, onPageClick, dataTestId}) => {
     }
   }, []);
 
+  // If totalPages updates for any reason, we may need to recalculate the range.
+  useEffect(() => {
+    // When the totalPages is updated and it is less than the rangeEnd, we _may_ need to recalculate the range we show.
+    if(totalPages < rangeEnd && totalPages-4 >= 1) {
+      setStart(totalPages-4);
+      return setEnd(totalPages);
+    }
+    if(totalPages < rangeEnd){
+      setStart(1);
+      return setEnd(totalPages);
+    }
+
+    if(totalPages > rangeEnd && totalPages <= 5) {
+      setStart(1);
+      return setEnd(totalPages);
+    }
+    if(totalPages > rangeEnd && page===rangeEnd-1 && page+2 <= totalPages) {
+      setStart(page-2);
+      return setEnd(page+2);
+    }
+    if(totalPages > rangeEnd && page===rangeEnd && page+1 <= totalPages) {
+      setStart(page-3);
+      return setEnd(page+1);
+    }
+
+  }, [totalPages])
+
   const _fetchAndUpdateRange = (page, start, end) => {
     onPageClick(page);
     setStart(start);

--- a/src/components/pagination/pagination.jsx
+++ b/src/components/pagination/pagination.jsx
@@ -13,24 +13,20 @@ const Pagination = ({page, totalPages, onPageClick, dataTestId}) => {
   const [rangeStart, setStart] = useState(1);
   const [rangeEnd, setEnd] = useState(5);
   useEffect(() => {
-    if(totalPages < 5){
-      setStart(1);
-      setEnd(totalPages);
+    if(totalPages < 5) {
+      _setRange(1, totalPages);
     }
     // This logic is called when mounting the component.
     // based on the page / totalPages, we need to determine the page range to render.
-    if(page+2 <= totalPages && page-2 >= 1){
-      setStart(page-2);
-      setEnd(page+2);
+    if(page+2 <= totalPages && page-2 >= 1) {
+      _setRange(page-2, page+2);
     }
     // Edge-case for if we mount the component with a page value of totalPages-1
     else if(page+1 === totalPages) {
-      setStart(totalPages-4);
-      setEnd(totalPages);
+      _setRange(totalPages-4, totalPages);
     }
     else if(page-4 >= 1) {
-      setStart(page-4);
-      setEnd(page);
+      _setRange(page-4, page);
     }
   }, []);
 
@@ -38,33 +34,31 @@ const Pagination = ({page, totalPages, onPageClick, dataTestId}) => {
   useEffect(() => {
     // When the totalPages is updated and it is less than the rangeEnd, we _may_ need to recalculate the range we show.
     if(totalPages < rangeEnd && totalPages-4 >= 1) {
-      setStart(totalPages-4);
-      return setEnd(totalPages);
+      return _setRange(totalPages-4, totalPages);
     }
     if(totalPages < rangeEnd){
-      setStart(1);
-      return setEnd(totalPages);
+      return _setRange(1, totalPages);
     }
 
     if(totalPages > rangeEnd && totalPages <= 5) {
-      setStart(1);
-      return setEnd(totalPages);
+      return _setRange(1, totalPages);
     }
     if(totalPages > rangeEnd && page===rangeEnd-1 && page+2 <= totalPages) {
-      setStart(page-2);
-      return setEnd(page+2);
+      return _setRange(page-2, page+2);
     }
     if(totalPages > rangeEnd && page===rangeEnd && page+1 <= totalPages) {
-      setStart(page-3);
-      return setEnd(page+1);
+      return _setRange(page-3, page+1);
     }
 
   }, [totalPages])
 
-  const _fetchAndUpdateRange = (page, start, end) => {
-    onPageClick(page);
+  const _setRange = (start, end) => {
     setStart(start);
     setEnd(end);
+  };
+  const _fetchAndUpdateRange = (page, start, end) => {
+    onPageClick(page);
+    _setRange(start, end);
   };
 
   const _onClick = (clickedPage) => {

--- a/src/components/project-modal/project-modal.jsx
+++ b/src/components/project-modal/project-modal.jsx
@@ -40,8 +40,8 @@ const ProjectModal = (props) => {
       return props.showNotification(response.error, "info", false);
     
     props.onClose();
-    if(props.refreshDashboard)
-      props.refreshDashboard();
+    if(props.refresh)
+      props.refresh();
     
     if(props.showNotification)
       props.showNotification(response.message, "info", true);
@@ -110,7 +110,7 @@ ProjectModal.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   showNotification: PropTypes.func,
   requestInProgress: PropTypes.bool.isRequired,
-  refreshDashboard: PropTypes.func,
+  refresh: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/project-modal/project-modal.spec.jsx
+++ b/src/components/project-modal/project-modal.spec.jsx
@@ -11,7 +11,7 @@ describe("<ProjectModal />", () => {
       onSubmit: jest.fn(),
       showNotification: jest.fn(),
       requestInProgress: false,
-      refreshDashboard: jest.fn()
+      refresh: jest.fn()
     };
   });
 
@@ -105,7 +105,7 @@ describe("<ProjectModal />", () => {
     expect(props.onSubmit).toHaveBeenCalledWith(name, description, true);
   });
 
-  it("should call onClose, refreshDashboard, and showNotification methods after a successful API call", async() => {
+  it("should call onClose, refresh, and showNotification methods after a successful API call", async() => {
     const expectedMessage = "unit test success message";
     props.onSubmit.mockReturnValueOnce({message: expectedMessage});
     const {getByTestId} = render(<ProjectModal {...props}/>);
@@ -115,7 +115,7 @@ describe("<ProjectModal />", () => {
     fireEvent.click(submitButton);
     await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
     expect(props.onClose).toHaveBeenCalledTimes(1);
-    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(props.refresh).toHaveBeenCalledTimes(1);
     expect(props.showNotification).toHaveBeenCalledWith(expectedMessage, "info", true);
   });
 

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -5,7 +5,7 @@ import {DashboardWrapper, DashboardActionButtons} from "./dashboard.styles";
 import Tabs from "../../components/tabs/tabs";
 import {showNotification} from "../../store/actions/notification";
 import {getDashboard} from "../../store/actions/dashboard";
-import {createProject, updateProject, deleteProject} from "../../store/actions/project";
+import {createProject, deleteProject} from "../../store/actions/project";
 import {getAvailableUsers, createMembership} from "../../store/actions/membership";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Button from "../../components/button/button";
@@ -25,7 +25,6 @@ const Dashboard = (props) => {
     projectRequestInProgress,
     membershipRequestInProgress,
     createProject,
-    updateProject,
     deleteProject,
     projects,
     historyPush,
@@ -33,7 +32,6 @@ const Dashboard = (props) => {
     createMembership
   } = props;
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
-  // const [editProjectData, setEditProject] = useState({});
   const [deleteProjectData, setDeleteProject] = useState({});
   const [membershipData, setMembershipData] = useState({});
 
@@ -92,7 +90,7 @@ const Dashboard = (props) => {
               onSubmit={createProject}
               showNotification={showNotification}
               requestInProgress={projectRequestInProgress}
-              refreshDashboard={getDashboard}
+              refresh={getDashboard}
             />
           )}
           {membershipData.project && (
@@ -106,15 +104,6 @@ const Dashboard = (props) => {
               project={membershipData.project}
             />
           )}
-          {/* {editProjectData.id && (
-            <ProjectModal
-              onClose={() => setEditProject({})}
-              onSubmit={updateProject}
-              requestInProgress={projectRequestInProgress}
-              refreshDashboard={getDashboard}
-              project={editProjectData}
-            />
-          )} */}
           {deleteProjectData.id && (
             <DeleteModal
               onClose={() => setDeleteProject({})}
@@ -146,7 +135,6 @@ Dashboard.propTypes = {
   projectRequestInProgress: PropTypes.bool.isRequired,
   membershipRequestInProgress: PropTypes.bool.isRequired,
   createProject: PropTypes.func.isRequired,
-  updateProject: PropTypes.func.isRequired,
   deleteProject: PropTypes.func.isRequired,
   showNotification: PropTypes.func.isRequired,
   historyPush: PropTypes.func.isRequired,
@@ -165,7 +153,6 @@ export default connect((state) => ({
   getDashboard,
   showNotification,
   createProject,
-  updateProject,
   deleteProject,
   historyPush: push,
   getAvailableUsers,

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -33,7 +33,7 @@ const Dashboard = (props) => {
     createMembership
   } = props;
   const [showNewProjectModal, setShowNewProjectModal] = useState(false);
-  const [editProjectData, setEditProject] = useState({});
+  // const [editProjectData, setEditProject] = useState({});
   const [deleteProjectData, setDeleteProject] = useState({});
   const [membershipData, setMembershipData] = useState({});
 
@@ -45,9 +45,9 @@ const Dashboard = (props) => {
     projects,
     actions: {
       deleteProject: (project) => setDeleteProject(project),
-      updateProject: (project) => setEditProject(project),
       addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
-      viewProject: (project) => historyPush(`/projects/${project.id}`)
+      viewProject: (project) => historyPush(`/projects/${project.id}`),
+      addStory: (project) => {}
     }
   };
 
@@ -65,14 +65,6 @@ const Dashboard = (props) => {
               startIcon={faPlus}
               dataTestId="dashboardNewProject"
               onClick={() => setShowNewProjectModal(true)}
-            />
-            <Button
-              small
-              secondary
-              label="New Story"
-              startIcon={faPlus}
-              dataTestId="dashboardNewStory"
-              onClick={() => {}}
             />
           </DashboardActionButtons>
           <Tabs dataTestId="dashboardTabs">
@@ -114,7 +106,7 @@ const Dashboard = (props) => {
               project={membershipData.project}
             />
           )}
-          {editProjectData.id && (
+          {/* {editProjectData.id && (
             <ProjectModal
               onClose={() => setEditProject({})}
               onSubmit={updateProject}
@@ -122,7 +114,7 @@ const Dashboard = (props) => {
               refreshDashboard={getDashboard}
               project={editProjectData}
             />
-          )}
+          )} */}
           {deleteProjectData.id && (
             <DeleteModal
               onClose={() => setDeleteProject({})}

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -73,9 +73,7 @@ describe("<Dashboard />", () => {
   it("should render the dashboard action buttons", () => {
     const {getByTestId, getByText} = render(<Dashboard />, store);
     expect(getByTestId("dashboardNewProject")).toBeDefined();
-    expect(getByTestId("dashboardNewStory")).toBeDefined();
     expect(getByText("New Project")).toBeDefined();
-    expect(getByText("New Story")).toBeDefined();
   });
 
   it("should render the tabs component", () => {
@@ -122,13 +120,13 @@ describe("<Dashboard />", () => {
     expect(getByTestId("dashboardProjects")).toBeDefined();
   });
 
-  it("should render the ProjectModal if the edit project action is clicked", () => {
-    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
-    const editButton = getByTestId("action.editProject");
-    expect(queryByTestId("projectModal.wrapper")).toBeNull();
-    fireEvent.click(editButton);
-    expect(queryByTestId("projectModal.wrapper")).toBeDefined();
-  });
+  // it("should render the ProjectModal if the edit project action is clicked", () => {
+  //   const {getByTestId, queryByTestId} = render(<Dashboard />, store);
+  //   const editButton = getByTestId("action.editProject");
+  //   expect(queryByTestId("projectModal.wrapper")).toBeNull();
+  //   fireEvent.click(editButton);
+  //   expect(queryByTestId("projectModal.wrapper")).toBeDefined();
+  // });
 
   it("should render the DeleteModal if the delete project action is clicked", () => {
     const {getByTestId, queryByTestId} = render(<Dashboard />, store);

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -120,14 +120,6 @@ describe("<Dashboard />", () => {
     expect(getByTestId("dashboardProjects")).toBeDefined();
   });
 
-  // it("should render the ProjectModal if the edit project action is clicked", () => {
-  //   const {getByTestId, queryByTestId} = render(<Dashboard />, store);
-  //   const editButton = getByTestId("action.editProject");
-  //   expect(queryByTestId("projectModal.wrapper")).toBeNull();
-  //   fireEvent.click(editButton);
-  //   expect(queryByTestId("projectModal.wrapper")).toBeDefined();
-  // });
-
   it("should render the DeleteModal if the delete project action is clicked", () => {
     const {getByTestId, queryByTestId} = render(<Dashboard />, store);
     const deleteButton = getByTestId("action.deleteProject");

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -123,7 +123,6 @@ const ProjectDetails = (props) => {
         ) : 
         (
           <Fragment>
-            {/* TODO: Test rendering of ProjectActionButtons and the modals they render as well */}
             {userRoles && <ProjectActionButtons>
               {userRoles.isAdmin && (
                 <Button

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -290,6 +290,7 @@ const ProjectDetails = (props) => {
             getAvailableUsers={getAvailableUsers}
             adminAllowed={!!(userRoles && userRoles.isAdmin)}
             project={project}
+            refresh={_reloadMemberships}
           />
         )}
     </ProjectDetailsWrapper>

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -9,10 +9,11 @@ import {
   ProjectID,
   ProjectVisibility,
   ProjectDescription,
-  Statistic
+  Statistic,
+  ProjectActionButtons
 } from "./project-details.styles";
-import {getProject} from "../../store/actions/project";
-import {getMemberships, deleteMembership, updateMembership} from "../../store/actions/membership";
+import {getProject, updateProject, deleteProject} from "../../store/actions/project";
+import {getMemberships, deleteMembership, updateMembership, createMembership, getAvailableUsers} from "../../store/actions/membership";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import Tabs from "../../components/tabs/tabs";
 import {formatDate} from "../../utils";
@@ -20,53 +21,81 @@ import {PageError} from "../../common-styles/base";
 import MembershipsTable from "../../components/memberships-table/memberships-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import MembershipModal from "../../components/membership-modal/membership-modal";
-import { faUserTimes } from "@fortawesome/free-solid-svg-icons";
+import { faTrash, faEdit, faUserTimes, faUserPlus } from "@fortawesome/free-solid-svg-icons";
+import Button from "../../components/button/button";
+import ProjectModal from "../../components/project-modal/project-modal";
+import {push} from "connected-react-router";
+import {showNotification} from "../../store/actions/notification";
 
 const ProjectDetails = (props) => {
+  // Extracting our props for use and declaring component states.
   const {
     projectIsLoading,
     membershipIsLoading,
     getProject,
     getMemberships,
     deleteMembership,
-    updateMembership
+    updateMembership,
+    updateProject,
+    deleteProject,
+    historyPush,
+    showNotification,
+    createMembership,
+    getAvailableUsers
   } = props;
   const [pageError, setPageError] = useState(undefined);
   const [projectData, setProjectData] = useState(undefined);
   const [membershipsPaginatedData, setMembershipsData] = useState(undefined);
   const [deleteMembershipData, setDeleteMembershipData] = useState({});
   const [editMembershipData, setEditMembershipData] = useState({});
+  const [showProjectEditModal, setShowProjectEditModal] = useState(false);
+  const [showProjectDeleteModal, setShowProjectDeleteModal] = useState(false);
+  const [showAddMemberModal, setShowAddMemberModal] = useState(false);
 
+  // This is called once, on component mount (inside useEffect)
   const _loadData = async() => {
     const projectId = props.match.params.projectId;
     const projectResponse = await getProject(projectId, true);
     const membershipResponse = await getMemberships(projectId);
 
-    if(projectResponse.error)
+    if(projectResponse && projectResponse.error)
       return setPageError(projectResponse.error);
     
-    if(membershipResponse.error)
+    if(membershipResponse && membershipResponse.error)
       return setPageError(membershipResponse.error);
 
     setProjectData(projectResponse);
     setMembershipsData(membershipResponse);
   };
 
+  // This is called when we delete or edit a membership.
   const _reloadMemberships = async() => {
     const {itemsPerPage, page} = membershipsPaginatedData;
     const projectId = props.match.params.projectId;
     const response = await getMemberships(projectId, page, itemsPerPage);
-    if(response.error)
+    if(response && response.error)
       return setPageError(response.error);
     
     setMembershipsData(response);
   };
 
+  // This is called when we edit project details.
+  const _reloadDetails = async() => {
+    const projectId = props.match.params.projectId;
+    const response = await getProject(projectId, true);
+    if(response && response.error)
+      return setPageError(response.error);
+    
+    setProjectData(response);
+  };
+
+  // Called once upon component mount, fetches all data.
   useEffect(() => {
     if(!projectData)
       _loadData();
   }, []);
 
+  // Props that will be utilized in the membership tab's Pagination component.
   const membershipsPagination = {
     itemsPerPage: membershipsPaginatedData && membershipsPaginatedData.itemsPerPage,
     page: membershipsPaginatedData && membershipsPaginatedData.page,
@@ -81,6 +110,7 @@ const ProjectDetails = (props) => {
       setMembershipsData(response);
     }
   };
+  
   const project = projectData && projectData.project;
   const userRoles = projectData && projectData.userRoles;
   return (
@@ -88,73 +118,110 @@ const ProjectDetails = (props) => {
       {pageError ? (
           <PageError>{pageError}</PageError>
         ) : 
-        (projectIsLoading || !projectData || !membershipsPaginatedData) ? (
+        (!projectData || !membershipsPaginatedData) ? (
           <LoadingSpinner alignCenter dataTestId="projectDetailsLoader" message={`Loading project details`} />
         ) : 
         (
-          <Tabs dataTestId="projectDetailsTabs">
-            <Tabs.TabHeaders>
-              <Tabs.Header>Details</Tabs.Header>
-              <Tabs.Header>Members</Tabs.Header>
-              <Tabs.Header>Backlog</Tabs.Header>
-            </Tabs.TabHeaders>
-            <Tabs.TabPanels>
-              <Tabs.Panel>
-                <DetailsSection>
-                  <DetailsBlock width="60%" inlineLeft>
-                    <ProjectID>{project.id}</ProjectID>
-                    <ProjectName>{project.name}</ProjectName>
-                    <ProjectVisibility isPrivate={project.isPrivate}>
-                      <span>{project.isPrivate ? "Private" : "Public"}</span>
-                    </ProjectVisibility>
-                    <ProjectDescription>
-                      <span>Description</span>
-                      {project.description ? project.description : <div>This project has no description.</div>}
-                    </ProjectDescription>
-                  </DetailsBlock>
-                  <DetailsBlock width="40%" inlineRight>
-                    <Statistic>
-                      <span>Create Date</span>
-                      {formatDate(project.createdOn)}
-                    </Statistic>
-                    {project.updatedOn && (
-                      <Statistic>
-                        <span>Last Modified</span>
-                        {formatDate(project.updatedOn)}
-                      </Statistic>
-                    )}
-                    <Statistic>
-                      <span>Total Members</span>
-                      {project.statistics.memberships}
-                    </Statistic>
-                    <Statistic>
-                      <span>Total Stories</span>
-                      {project.statistics.stories}
-                    </Statistic>
-                  </DetailsBlock>
-                </DetailsSection>
-              </Tabs.Panel>
-              <Tabs.Panel>
-                {membershipsPaginatedData.memberships.length ? (
-                  <MembershipsTable
-                    memberships={membershipsPaginatedData.memberships}
-                    userRoles={userRoles}
-                    actions={{
-                      deleteMembership: (membership) => setDeleteMembershipData(membership),
-                      editMembership: (membership) => setEditMembershipData(membership)
-                    }}
-                    pagination={membershipsPagination}
+          <Fragment>
+            {/* TODO: Test rendering of ProjectActionButtons and the modals they render as well */}
+            {userRoles && <ProjectActionButtons>
+              {userRoles.isAdmin && (
+                <Button
+                  small
+                  secondary
+                  danger
+                  label="Delete Project"
+                  startIcon={faTrash}
+                  dataTestId="detailsDeleteProject"
+                  onClick={() => setShowProjectDeleteModal(true)}
+                />
+              )}
+              {(userRoles.isManager || userRoles.isAdmin) && (
+                <Fragment>
+                  <Button
+                    small
+                    secondary
+                    label="Edit Project"
+                    startIcon={faEdit}
+                    dataTestId="detailsEditProject"
+                    onClick={() => setShowProjectEditModal(true)}
                   />
-                ) : (
-                  <div>This project has no members</div>
-                )}
-              </Tabs.Panel>
-              <Tabs.Panel>
-                Backlog here.
-              </Tabs.Panel>
-            </Tabs.TabPanels>
-          </Tabs>
+                  <Button
+                    small
+                    secondary
+                    label="Add Member"
+                    startIcon={faUserPlus}
+                    dataTestId="detailsNewMember"
+                    onClick={() => setShowAddMemberModal(true)}
+                  />
+                </Fragment>
+              )}
+            </ProjectActionButtons>}
+            <Tabs dataTestId="projectDetailsTabs">
+              <Tabs.TabHeaders>
+                <Tabs.Header>Details</Tabs.Header>
+                <Tabs.Header>Members</Tabs.Header>
+                <Tabs.Header>Backlog</Tabs.Header>
+              </Tabs.TabHeaders>
+              <Tabs.TabPanels>
+                <Tabs.Panel>
+                  <DetailsSection>
+                    <DetailsBlock width="60%" inlineLeft>
+                      <ProjectID>{project.id}</ProjectID>
+                      <ProjectName>{project.name}</ProjectName>
+                      <ProjectVisibility isPrivate={project.isPrivate}>
+                        <span>{project.isPrivate ? "Private" : "Public"}</span>
+                      </ProjectVisibility>
+                      <ProjectDescription>
+                        <span>Description</span>
+                        {project.description ? project.description : <div>This project has no description.</div>}
+                      </ProjectDescription>
+                    </DetailsBlock>
+                    <DetailsBlock width="40%" inlineRight>
+                      <Statistic>
+                        <span>Create Date</span>
+                        {formatDate(project.createdOn)}
+                      </Statistic>
+                      {project.updatedOn && (
+                        <Statistic>
+                          <span>Last Modified</span>
+                          {formatDate(project.updatedOn)}
+                        </Statistic>
+                      )}
+                      <Statistic>
+                        <span>Total Members</span>
+                        {project.statistics.memberships}
+                      </Statistic>
+                      <Statistic>
+                        <span>Total Stories</span>
+                        {project.statistics.stories}
+                      </Statistic>
+                    </DetailsBlock>
+                  </DetailsSection>
+                </Tabs.Panel>
+                <Tabs.Panel>
+                  {membershipsPaginatedData.memberships.length ? (
+                    <MembershipsTable
+                      memberships={membershipsPaginatedData.memberships}
+                      userRoles={userRoles}
+                      actions={{
+                        deleteMembership: (membership) => setDeleteMembershipData(membership),
+                        editMembership: (membership) => setEditMembershipData(membership)
+                      }}
+                      pagination={membershipsPagination}
+                    />
+                  ) : (
+                    <div>This project has no members</div>
+                  )}
+                </Tabs.Panel>
+                <Tabs.Panel>
+                  Backlog here.
+                </Tabs.Panel>
+              </Tabs.TabPanels>
+            </Tabs>
+          </Fragment>
         )}
+        {/* Modal City, pop: 5 */}
         {deleteMembershipData.id && (
           <DeleteModal
             onClose={() => setDeleteMembershipData({})}
@@ -189,6 +256,43 @@ const ProjectDetails = (props) => {
             refresh={_reloadMemberships}
           />
         )}
+        {showProjectEditModal && (
+          <ProjectModal
+            onClose={() => setShowProjectEditModal(false)}
+            onSubmit={updateProject}
+            requestInProgress={projectIsLoading}
+            refresh={_reloadDetails}
+            project={project}
+          />
+        )}
+        {showProjectDeleteModal && (
+          <DeleteModal
+            onClose={() => setShowProjectDeleteModal(false)}
+            onSubmit={deleteProject}
+            dataTestId="projectDeleteModal"
+            headerText="Delete Project"
+            bodyText={`All memberships and stories belonging to this project will be
+            deleted as well. Please proceed with caution.`}
+            resource={project}
+            expectedInput={project.name}
+            inputProps={{
+              label: "Project Name",
+              placeholder: "Enter the project's name"
+            }}
+            refresh={() => historyPush("/dashboard")}
+            showNotification={showNotification}
+          />
+        )}
+        {showAddMemberModal && (
+          <MembershipModal
+            onClose={() => setShowAddMemberModal(false)}
+            onSubmit={createMembership}
+            requestInProgress={membershipIsLoading}
+            getAvailableUsers={getAvailableUsers}
+            adminAllowed={!!(userRoles && userRoles.isAdmin)}
+            project={project}
+          />
+        )}
     </ProjectDetailsWrapper>
   );
 };
@@ -199,7 +303,13 @@ ProjectDetails.propTypes = {
   getProject: PropTypes.func.isRequired,
   getMemberships: PropTypes.func.isRequired,
   deleteMembership: PropTypes.func.isRequired,
-  updateMembership: PropTypes.func.isRequired
+  updateMembership: PropTypes.func.isRequired,
+  updateProject: PropTypes.func.isRequired,
+  deleteProject: PropTypes.func.isRequired,
+  historyPush: PropTypes.func.isRequired,
+  showNotification: PropTypes.func.isRequired,
+  createMembership: PropTypes.func.isRequired,
+  getAvailableUsers: PropTypes.func.isRequired
 };
 
 export default connect((state) => ({
@@ -207,7 +317,13 @@ export default connect((state) => ({
   membershipIsLoading: state.membership.isLoading
 }), {
   getProject,
+  updateProject,
+  deleteProject,
   getMemberships,
   deleteMembership,
-  updateMembership
+  updateMembership,
+  historyPush: push,
+  showNotification,
+  createMembership,
+  getAvailableUsers
 })(ProjectDetails);

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -102,7 +102,9 @@ describe("<ProjectDetails />", () => {
         isLoading: true
       }
     });
-    store.dispatch = jest.fn().mockReturnValueOnce({}).mockReturnValueOnce({});
+    // Kinda hacky but we dont use projectIsLoading to determine if we show the spinner or not anymore...
+    // instead we just show the spinner if we have undefined data.
+    store.dispatch = jest.fn().mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
     const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("projectDetailsLoader")).toBeDefined();

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -50,8 +50,8 @@ describe("<ProjectDetails />", () => {
       }
     },
     userRoles: {
-      isAdmin: false,
-      isManager: true,
+      isAdmin: true,
+      isManager: false,
       isDeveloper: false,
       isViewer: false
     }
@@ -248,5 +248,88 @@ describe("<ProjectDetails />", () => {
     expect(queryByTestId("membershipModal.wrapper")).toBeNull();
     fireEvent.click(editAction);
     expect(queryByTestId("membershipModal.wrapper")).toBeDefined();
+  });
+
+  it("should render the 'Delete Project' button if the user has admin permissions", async() => {
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("detailsDeleteProject")).toBeDefined();
+    expect(getByText("Delete Project")).toBeDefined();
+  });
+
+  it("should not render the 'Delete Project' button if the user has non-admin permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("detailsDeleteProject")).toBeNull();
+    expect(queryByText("Delete Project")).toBeNull();
+  });
+
+  it("should render the delete project modal when 'Delete Project' is clicked", async() => {
+    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const deleteButton = getByTestId("detailsDeleteProject");
+    fireEvent.click(deleteButton);
+    expect(getByTestId("projectDeleteModal.wrapper")).toBeDefined();
+  });
+
+  it("should render the 'Edit Project' button if the user has admin/manager permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("detailsEditProject")).toBeDefined();
+    expect(getByText("Edit Project")).toBeDefined();
+  });
+
+  it("should not render the 'Edit Project' button if the user has insufficient permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isDeveloper: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("detailsEditProject")).toBeNull();
+    expect(queryByText("Edit Project")).toBeNull();
+  });
+
+  it("should render the edit project modal when 'Edit Project' is clicked", async() => {
+    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const editButton = getByTestId("detailsEditProject");
+    fireEvent.click(editButton);
+    expect(getByTestId("projectModal.wrapper")).toBeDefined();
+  });
+
+  it("should render the 'Add Member' button if the user has admin/manager permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("detailsNewMember")).toBeDefined();
+    expect(getByText("Add Member")).toBeDefined();
+  });
+
+  it("should not render the 'Add Member' button if the user has insufficient permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isDeveloper: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("detailsNewMember")).toBeNull();
+    expect(queryByText("Add Member")).toBeNull();
+  });
+
+  it("should render the add member modal when 'Add Member' is clicked", async() => {
+    store.dispatch.mockReturnValueOnce({users: []});
+    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const addMemberButton = getByTestId("detailsNewMember");
+    fireEvent.click(addMemberButton);
+    expect(getByTestId("membershipModal.wrapper")).toBeDefined();
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });
 });

--- a/src/containers/project-details/project-details.styles.js
+++ b/src/containers/project-details/project-details.styles.js
@@ -8,6 +8,7 @@ import {
   primaryBlue,
   primaryGreen
 } from "../../common-styles/variables";
+import {ButtonWrapper} from "../../components/button/button.styles";
 
 export const ProjectDetailsWrapper = styled.div`
   position: relative;
@@ -138,5 +139,24 @@ export const Statistic = styled.div`
   &:hover span {
     color: ${black};
     border-color: ${black};
+  }
+`;
+
+export const ProjectActionButtons = styled.div`
+  position: absolute;
+  right: 50px;
+  top: 30px;
+  z-index: 2999;
+
+  & ${ButtonWrapper} {
+    display: inline-block;
+  }
+
+  & ${ButtonWrapper} {
+    margin-left: 5px;
+  }
+
+  & ${ButtonWrapper}:first-of-type {
+    margin-left: 0;
   }
 `;


### PR DESCRIPTION
This PR tweaks some of the features available on `Dashboard` and `ProjectDetails`. contains:
- Added alternative red color variables.
- Updated `Button` styles, allowing for a secondary-style red button.
- Removed `updateProject` functionality from `Dashboard`. removed Dashboard/Table tests around this functionality.
- Moved `New Story` button on `Dashboard` from the general actions to the ProjectsTable actions. updated unit tests.
- Updated ProjectModal prop-name to `refresh` and updated instances / unit tests.
- Updated `Pagination` logic to update displayed page-range based on `totalPages` prop updates.
- Added `refresh` prop to `MembershipModal` used for adding new members on the project details page.
- Added general `Actions` to `ProjectDetails`:
  * allows editing / deleting Project and Adding new members.
  * conditionally renders the Actions based on user permissions.
  * added unit tests for all new functionality implemented around these Actions.