### PR TITLE
Add ActionsMenu Component

### DIFF
--- a/src/components/actions-menu/actions-flyout.jsx
+++ b/src/components/actions-menu/actions-flyout.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  FlyoutWrapper,
+  ItemList,
+  Item
+} from "./actions-menu.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const Flyout = ({menuItems, closeMenu, dataTestId}) => {
+  const _handleClick = useCallback(() => {
+    closeMenu();
+  }, [closeMenu]);
+
+  useEffect(() => {
+    window.addEventListener("click", _handleClick);
+    return () => window.removeEventListener("click", _handleClick);
+  });
+
+  const wrapperProps = {};
+  const listProps = {};
+  if(dataTestId) {
+    wrapperProps["data-testid"] = `${dataTestId}.flyout`;
+    listProps["data-testid"] = `${dataTestId}.itemList`;
+  }
+  return (
+    <FlyoutWrapper {...wrapperProps}>
+      <ItemList {...listProps}>
+        {menuItems.map(({icon, label, onClick}, index) => {
+          const itemProps = {
+            key: index,
+            onClick
+          };
+          if(dataTestId)
+            itemProps["data-testid"] = `${dataTestId}.item.${index}`;
+          return (
+            <Item {...itemProps}>
+              {icon && <FontAwesomeIcon icon={icon}/>}{label}
+            </Item>
+          )
+        })}
+      </ItemList>
+    </FlyoutWrapper>
+  );
+};
+
+Flyout.propTypes = {
+  dataTestId: PropTypes.string,
+  menuItems: PropTypes.array.isRequired,
+  closeMenu: PropTypes.func.isRequired
+};
+
+export default Flyout;

--- a/src/components/actions-menu/actions-menu.jsx
+++ b/src/components/actions-menu/actions-menu.jsx
@@ -1,13 +1,13 @@
 import React, {useState} from "react";
 import PropTypes from "prop-types";
 import {
-  ProjectActionsWrapper
+  ActionsWrapper
 } from "./actions-menu.styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faCog} from "@fortawesome/free-solid-svg-icons";
 import ActionsFlyout from "./actions-flyout";
 
-const ProjectActionsMenu = ({menuItems, dataTestId}) => {
+const ActionsMenu = ({menuItems, dataTestId}) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const wrapperProps = {
     menuOpen: showFlyout,
@@ -16,16 +16,16 @@ const ProjectActionsMenu = ({menuItems, dataTestId}) => {
   if(dataTestId)
     wrapperProps["data-testid"] = dataTestId;
   return (
-    <ProjectActionsWrapper {...wrapperProps}>
+    <ActionsWrapper {...wrapperProps}>
       <span><FontAwesomeIcon icon={faCog} size="sm" fixedWidth/>&nbsp;Actions</span>
       {showFlyout && <ActionsFlyout menuItems={menuItems} closeMenu={() => setShowFlyout(false)} dataTestId={dataTestId} />}
-    </ProjectActionsWrapper>
+    </ActionsWrapper>
   );
 };
 
-ProjectActionsMenu.propTypes = {
+ActionsMenu.propTypes = {
   dataTestId: PropTypes.string,
   menuItems: PropTypes.array.isRequired
 };
 
-export default ProjectActionsMenu;
+export default ActionsMenu;

--- a/src/components/actions-menu/actions-menu.jsx
+++ b/src/components/actions-menu/actions-menu.jsx
@@ -1,0 +1,31 @@
+import React, {useState} from "react";
+import PropTypes from "prop-types";
+import {
+  ProjectActionsWrapper
+} from "./actions-menu.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faCog} from "@fortawesome/free-solid-svg-icons";
+import ActionsFlyout from "./actions-flyout";
+
+const ProjectActionsMenu = ({menuItems, dataTestId}) => {
+  const [showFlyout, setShowFlyout] = useState(false);
+  const wrapperProps = {
+    menuOpen: showFlyout,
+    onClick: () => setShowFlyout(true)
+  };
+  if(dataTestId)
+    wrapperProps["data-testid"] = dataTestId;
+  return (
+    <ProjectActionsWrapper {...wrapperProps}>
+      <span><FontAwesomeIcon icon={faCog} size="sm" fixedWidth/>&nbsp;Actions</span>
+      {showFlyout && <ActionsFlyout menuItems={menuItems} closeMenu={() => setShowFlyout(false)} dataTestId={dataTestId} />}
+    </ProjectActionsWrapper>
+  );
+};
+
+ProjectActionsMenu.propTypes = {
+  dataTestId: PropTypes.string,
+  menuItems: PropTypes.array.isRequired
+};
+
+export default ProjectActionsMenu;

--- a/src/components/actions-menu/actions-menu.spec.jsx
+++ b/src/components/actions-menu/actions-menu.spec.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import ActionsMenu from "./actions-menu";
+import { render } from "../../test-utils";
+import { fireEvent } from "@testing-library/react";
+
+describe("<ActionsMenu />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      dataTestId: "testActionsMenu",
+      menuItems: [{
+        label: "Taco Tuesday",
+        onClick: jest.fn()
+      },{
+        label: "Wacky Wednesday",
+        onClick: jest.fn()
+      },{
+        label: "Thirsty Thursday",
+        onClick: jest.fn()
+      }]
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<ActionsMenu {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render the 'Actions' text", () => {
+    const {getByText} = render(<ActionsMenu {...props}/>);
+    expect(getByText("Actions")).toBeDefined();
+  });
+
+  it("should render flyout on click", () => {
+    const {queryByTestId} = render(<ActionsMenu {...props}/>);
+    const actionsMenu = queryByTestId(props.dataTestId);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeNull();
+    fireEvent.click(actionsMenu);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeDefined();
+  });
+
+  it("should render flyout list and items", () => {
+    const {getByText, getByTestId} = render(<ActionsMenu {...props}/>);
+    const actionsMenu = getByTestId(props.dataTestId);
+    fireEvent.click(actionsMenu);
+    expect(getByTestId(`${props.dataTestId}.itemList`)).toBeDefined();
+    expect(getByTestId(`${props.dataTestId}.item.0`)).toBeDefined();
+    expect(getByText("Taco Tuesday")).toBeDefined();
+    expect(getByTestId(`${props.dataTestId}.item.1`)).toBeDefined();
+    expect(getByText("Wacky Wednesday")).toBeDefined();
+    expect(getByTestId(`${props.dataTestId}.item.2`)).toBeDefined();
+    expect(getByText("Thirsty Thursday")).toBeDefined();
+  });
+
+  it("should call each items onClick prop on click", () => {
+    const {getByTestId} = render(<ActionsMenu {...props}/>);
+    const actionsMenu = getByTestId(props.dataTestId);
+    
+    fireEvent.click(actionsMenu);
+    const item1 = getByTestId(`${props.dataTestId}.item.0`);
+    fireEvent.click(item1);
+    expect(props.menuItems[0].onClick).toHaveBeenCalled();
+
+    fireEvent.click(actionsMenu);
+    const item2 = getByTestId(`${props.dataTestId}.item.1`);
+    fireEvent.click(item2);
+    expect(props.menuItems[1].onClick).toHaveBeenCalled();
+
+    fireEvent.click(actionsMenu);
+    const item3 = getByTestId(`${props.dataTestId}.item.2`);
+    fireEvent.click(item3);
+    expect(props.menuItems[2].onClick).toHaveBeenCalled();
+  });
+
+  it("should close the flyout after any click", () => {
+    const {getByTestId, queryByTestId} = render(<ActionsMenu {...props}/>);
+    const actionsMenu = getByTestId(props.dataTestId);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeNull();
+    fireEvent.click(actionsMenu);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeDefined();
+    fireEvent.click(actionsMenu);
+    expect(queryByTestId(`${props.dataTestId}.flyout`)).toBeNull();
+  });
+});

--- a/src/components/actions-menu/actions-menu.styles.js
+++ b/src/components/actions-menu/actions-menu.styles.js
@@ -1,0 +1,81 @@
+import styled, {css} from "styled-components";
+import { transparent, black, black80, black1a, black26, white } from "../../common-styles/variables";
+import { fadeIn } from "../../common-styles/animations";
+
+export const ProjectActionsWrapper = styled.div`
+  position: absolute;
+  right: 50px;
+  top: 30px;
+  z-index: 2999;
+  border: 1px solid ${transparent};
+  color: ${black80};
+  transition: border-color 100ms linear, color 100ms linear;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  
+  ${({menuOpen}) => menuOpen && css`
+    border-color: ${black80};
+    color: ${black};
+  `}
+
+  &:hover {
+    border-color: ${black80};
+    color: ${black};
+  }
+
+  & span {
+    font-weight: 500;
+    font-size: 18px;
+    user-select: none;
+  }
+`;
+
+export const FlyoutWrapper = styled.div`
+  position: absolute;
+  border-radius: 5px;
+  border: 1px solid ${black};
+  left: -71px;
+  width: 175px;
+  min-width: 175px;
+  height: auto;
+  background-color: ${white};
+  color: ${black};
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 5px;
+  padding-right: 5px;
+  -webkit-box-shadow: 0px 8px 15px 2px rgba(0,0,0,0.25);
+  -moz-box-shadow: 0px 8px 15px 2px rgba(0,0,0,0.25);
+  box-shadow: 0px 8px 15px 2px rgba(0,0,0,0.25);
+  animation: 125ms linear 0s 1 ${fadeIn};
+`;
+
+export const Item = styled.li`
+  user-select: none;
+  cursor: pointer;
+  padding: 5px 15px 5px 15px;
+  border-radius: 5px;
+  border: 1px solid ${white};
+  transition: background-color 125ms linear;
+
+  &:hover {
+    background-color: ${black1a};
+  }
+
+  &:active {
+    background-color: ${black26};
+  }
+
+  & svg {
+    margin-right: 5px;
+  }
+`;
+
+export const ItemList = styled.ul`
+  margin: 0;
+  padding: 0 0 2px 0;
+  list-style: none;
+  text-align: left;
+`;

--- a/src/components/actions-menu/actions-menu.styles.js
+++ b/src/components/actions-menu/actions-menu.styles.js
@@ -2,7 +2,7 @@ import styled, {css} from "styled-components";
 import { transparent, black, black80, black1a, black26, white } from "../../common-styles/variables";
 import { fadeIn } from "../../common-styles/animations";
 
-export const ProjectActionsWrapper = styled.div`
+export const ActionsWrapper = styled.div`
   position: absolute;
   right: 50px;
   top: 30px;

--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Table from "../table/table";
+import {TableValue} from "../table/table.styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faArrowRight, faTrash, faBook, faUserPlus} from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "../tooltip/tooltip";
@@ -41,7 +42,10 @@ const DashboardProjectsTable = ({projects, actions}) => {
     dataTestId: "dashboardProjects",
     headers: [{
       label: "Name",
-      keyName: "name"
+      keyName: "name",
+      format: (name) => (
+        <TableValue truncated maxWidth="300px">{name}</TableValue>
+      )
     }, {
       label: "Unique ID",
       keyName: "id"

--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Table from "../table/table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -8,36 +8,28 @@ import {formatDate, getPermissionLevel} from "../../utils";
 import {ActionsWrapper, Action} from "../table/table.styles";
 
 const DashboardProjectsTable = ({projects, actions}) => {
-  const [hoverMap, setHover] = useState(projects.reduce((prev, curr) => {
-    if(curr.id)
-      return Object.assign(prev, {[curr.id]: false});
-    
-    return prev;
-  }, {}));
-
   const _renderActions = (row) => {
     const {deleteProject, addStory, addMember, viewProject} = actions;
     const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
-    const rowHovered = hoverMap[row.id];
     const adminAllowed = isAdmin;
     const managerAllowed = (isAdmin || isManager);
     const developerAllowed = (isAdmin || isManager || isDeveloper);
     const viewerAllowed = (isAdmin || isManager || isDeveloper || isViewer);
     return (
       <ActionsWrapper>
-        <Action data-testid="action.deleteProject" highlightAction={rowHovered && adminAllowed} onClick={() => adminAllowed && deleteProject(row)}>
+        <Action data-testid="action.deleteProject" highlightAction={adminAllowed} onClick={() => adminAllowed && deleteProject(row)}>
           <FontAwesomeIcon icon={faTrash} fixedWidth />
           {adminAllowed && <Tooltip text={"Delete Project"} />}
         </Action>
-        <Action data-testid="action.addMember" highlightAction={rowHovered && managerAllowed} onClick={() => managerAllowed && addMember(row, adminAllowed)}>
+        <Action data-testid="action.addMember" highlightAction={managerAllowed} onClick={() => managerAllowed && addMember(row, adminAllowed)}>
           <FontAwesomeIcon icon={faUserPlus} fixedWidth />
           {managerAllowed && <Tooltip text={"Add Member"} />}
         </Action>
-        <Action data-testid="action.addStory" highlightAction={rowHovered && developerAllowed} onClick={() => developerAllowed && addStory(row)}>
+        <Action data-testid="action.addStory" highlightAction={developerAllowed} onClick={() => developerAllowed && addStory(row)}>
           <FontAwesomeIcon icon={faBook} fixedWidth />
           {developerAllowed && <Tooltip text={"Add Story"} />}
         </Action>
-        <Action data-testid="action.viewProject" highlightAction={rowHovered && viewerAllowed} onClick={() => viewerAllowed && viewProject(row)}>
+        <Action data-testid="action.viewProject" highlightAction={viewerAllowed} onClick={() => viewerAllowed && viewProject(row)}>
           <FontAwesomeIcon icon={faArrowRight} fixedWidth />
           {viewerAllowed && <Tooltip text={"View Project"} />}
         </Action>
@@ -69,11 +61,7 @@ const DashboardProjectsTable = ({projects, actions}) => {
       label: "Actions",
       renderActions: _renderActions
     }],
-    rows: projects,
-    rowProps: (row) => ({
-      onMouseOver: () => setHover({...hoverMap, [row.id]: true}),
-      onMouseLeave: () => setHover({...hoverMap, [row.id]: false})
-    })
+    rows: projects
   };
 
   return (

--- a/src/components/membership-modal/membership-modal.styles.js
+++ b/src/components/membership-modal/membership-modal.styles.js
@@ -34,5 +34,11 @@ export const ProjectSection = styled.div`
     display: inline-block;
     font-weight: bold;
     font-size: 18px;
+    vertical-align: bottom;
+    overflow: hidden;
+    width: 400px;
+    line-height: 24px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 `;

--- a/src/components/memberships-table/memberships-table.jsx
+++ b/src/components/memberships-table/memberships-table.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Table from "../table/table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -10,13 +10,6 @@ import {MembershipsTableWrapper, PaginationSection} from "./memberships-table.st
 import Pagination from "../pagination/pagination";
 
 const MembershipsTable = ({memberships, userRoles, actions, pagination}) => {
-  const [hoverMap, setHover] = useState(memberships.reduce((prev, curr) => {
-    if(curr.id)
-      return Object.assign(prev, {[curr.id]: false});
-    
-    return prev;
-  }, {}));
-
   const _renderActions = (row) => {//row is a membership object in this Table instance.
     const {deleteMembership, editMembership} = actions;
     // determine logged in user's permission levels
@@ -28,14 +21,13 @@ const MembershipsTable = ({memberships, userRoles, actions, pagination}) => {
 
     // based on the requesting user's roles and a member's existing roles, we can determine if actions are allowed.
     const actionAllowed = isAdmin ? adminPermissions : (adminPermissions || managerPermissions);
-    const rowHovered = hoverMap[row.id];
     return (
       <ActionsWrapper>
-        <Action data-testid="action.deleteMembership" highlightAction={rowHovered && actionAllowed} onClick={() => actionAllowed && deleteMembership(row)}>
+        <Action data-testid="action.deleteMembership" highlightAction={actionAllowed} onClick={() => actionAllowed && deleteMembership(row)}>
           <FontAwesomeIcon icon={faUserTimes} fixedWidth />
           {actionAllowed && <Tooltip text={"Remove Member"} />}
         </Action>
-        <Action data-testid="action.editMembership" highlightAction={rowHovered && actionAllowed} onClick={() => actionAllowed && editMembership(row)}>
+        <Action data-testid="action.editMembership" highlightAction={actionAllowed} onClick={() => actionAllowed && editMembership(row)}>
           <FontAwesomeIcon icon={faUserEdit} fixedWidth />
           {actionAllowed && <Tooltip text={"Edit Roles"} />}
         </Action>
@@ -61,11 +53,7 @@ const MembershipsTable = ({memberships, userRoles, actions, pagination}) => {
       label: "Actions",
       renderActions: _renderActions
     }],
-    rows: memberships,
-    rowProps: (row) => ({
-      onMouseOver: () => setHover({...hoverMap, [row.id]: true}),
-      onMouseLeave: () => setHover({...hoverMap, [row.id]: false})
-    })
+    rows: memberships
   };
 
   const paginationProps = {

--- a/src/components/memberships-table/memberships-table.jsx
+++ b/src/components/memberships-table/memberships-table.jsx
@@ -8,6 +8,7 @@ import {formatDate, getPermissionLevel} from "../../utils";
 import {ActionsWrapper, Action} from "../table/table.styles";
 import {MembershipsTableWrapper, PaginationSection} from "./memberships-table.styles";
 import Pagination from "../pagination/pagination";
+import {TableValue} from "../table/table.styles";
 
 const MembershipsTable = ({memberships, userRoles, actions, pagination}) => {
   const _renderActions = (row) => {//row is a membership object in this Table instance.
@@ -40,7 +41,9 @@ const MembershipsTable = ({memberships, userRoles, actions, pagination}) => {
     headers: [{
       label: "User",
       keyName: "user",
-      format: (user) => user.displayName
+      format: (user) => (
+        <TableValue truncated maxWidth="255px">{user.displayName}</TableValue>
+      )
     }, {
       label: "Permission Level",
       keyName: "roles",

--- a/src/components/page-header/page-header.styles.js
+++ b/src/components/page-header/page-header.styles.js
@@ -10,6 +10,8 @@ export const PageHeaderWrapper = styled.div`
   padding-left: 25px;
   padding-right: 25px;
   padding-top: 11px;
+  word-break: break-all;
+  overflow: hidden;
 
   ${({textCenter}) => textCenter && css`
     text-align: center;
@@ -22,7 +24,7 @@ export const PageHeaderWrapper = styled.div`
 
   & h1 {
     margin: 0;
-    font-size: 40px;
+    font-size: 35px;
     height: 100%;
 
     & svg {

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -45,6 +45,16 @@ export const ActionsWrapper = styled.div`
   }
 `;
 
+export const TruncatedValue = styled.div`
+  max-width: 300px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  ${({maxWidth}) => maxWidth && css`
+    max-width: ${maxWidth};
+  `}
+`;
+
 export const TableWrapper = styled.div`
   position: relative;
 
@@ -75,7 +85,9 @@ export const TableWrapper = styled.div`
   }
 `;
 
-// & tbody tr:hover ${Action} {
-//   ${console.log(Action)}
-//   color: ${black};
+// & .truncated {
+//   max-width: 300px;
+//   overflow: hidden;
+//   white-space: nowrap;
+//   text-overflow: ellipsis;
 // }

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -15,11 +15,6 @@ export const Action = styled.div`
   color: ${black33};
   transition: color 100ms linear;
 
-  ${({highlightAction}) => highlightAction && css`
-    color: ${black};
-    cursor: pointer;
-  `}
-
   &:hover ${TooltipWrapper} {
     font-size: 16px;
     visibility: visible;
@@ -27,6 +22,13 @@ export const Action = styled.div`
     left: -50px;
     bottom: -33px;
   }
+
+  ${({highlightAction}) => highlightAction && css`
+    table tr:hover & {
+      color: ${black};
+      cursor: pointer;
+    }
+  `}
 `;
 
 export const ActionsWrapper = styled.div`
@@ -72,3 +74,8 @@ export const TableWrapper = styled.div`
     }
   }
 `;
+
+// & tbody tr:hover ${Action} {
+//   ${console.log(Action)}
+//   color: ${black};
+// }

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -45,13 +45,15 @@ export const ActionsWrapper = styled.div`
   }
 `;
 
-export const TruncatedValue = styled.div`
-  max-width: 300px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+export const TableValue = styled.div`
   ${({maxWidth}) => maxWidth && css`
     max-width: ${maxWidth};
+  `}
+
+  ${({truncated}) => truncated && css`
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   `}
 `;
 

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -46,6 +46,7 @@ export const ActionsWrapper = styled.div`
 `;
 
 export const TableValue = styled.div`
+  width: auto;
   ${({maxWidth}) => maxWidth && css`
     max-width: ${maxWidth};
   `}
@@ -64,6 +65,7 @@ export const TableWrapper = styled.div`
     width: 100%;
     border-collapse: collapse;
     font-size: 18px;
+    overflow: hidden;
 
     & th {
       width: 10%;
@@ -86,10 +88,3 @@ export const TableWrapper = styled.div`
     }
   }
 `;
-
-// & .truncated {
-//   max-width: 300px;
-//   overflow: hidden;
-//   white-space: nowrap;
-//   text-overflow: ellipsis;
-// }

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -1,20 +1,20 @@
 import React, {useEffect, useState, Fragment} from "react";
 import PropTypes from "prop-types";
 import {connect} from "react-redux";
-import {DashboardWrapper, DashboardActionButtons} from "./dashboard.styles";
+import {DashboardWrapper} from "./dashboard.styles";
 import Tabs from "../../components/tabs/tabs";
 import {showNotification} from "../../store/actions/notification";
 import {getDashboard} from "../../store/actions/dashboard";
 import {createProject, deleteProject} from "../../store/actions/project";
 import {getAvailableUsers, createMembership} from "../../store/actions/membership";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
-import Button from "../../components/button/button";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
 import ProjectsTable from "../../components/dashboard-projects-table/dashboard-projects-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import {push} from "connected-react-router";
 import MembershipModal from "../../components/membership-modal/membership-modal";
+import ActionsMenu from "../../components/actions-menu/actions-menu";
 
 const Dashboard = (props) => {
   const {
@@ -49,22 +49,22 @@ const Dashboard = (props) => {
     }
   };
 
+  const actionsMenuProps = {
+    dataTestId: "dashboardActionsMenu",
+    menuItems: [{
+      icon: faPlus,
+      label: "New Project",
+      onClick: () => setShowNewProjectModal(true)
+    }]
+  };
+
   return (
     <DashboardWrapper>
       {isLoading ? (
         <LoadingSpinner alignCenter dataTestId="dashboardLoader" message={`Loading Dashboard for ${userInfo.displayName}`}/>
       ) : (
         <Fragment>
-          <DashboardActionButtons>
-            <Button
-              small
-              secondary
-              label="New Project"
-              startIcon={faPlus}
-              dataTestId="dashboardNewProject"
-              onClick={() => setShowNewProjectModal(true)}
-            />
-          </DashboardActionButtons>
+          <ActionsMenu {...actionsMenuProps} />
           <Tabs dataTestId="dashboardTabs">
             <Tabs.TabHeaders>
               <Tabs.Header>My Projects</Tabs.Header>

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -15,6 +15,7 @@ import DeleteModal from "../../components/delete-modal/delete-modal";
 import {push} from "connected-react-router";
 import MembershipModal from "../../components/membership-modal/membership-modal";
 import ActionsMenu from "../../components/actions-menu/actions-menu";
+import PageHeader from "../../components/page-header/page-header";
 
 const Dashboard = (props) => {
   const {
@@ -64,6 +65,7 @@ const Dashboard = (props) => {
         <LoadingSpinner alignCenter dataTestId="dashboardLoader" message={`Loading Dashboard for ${userInfo.displayName}`}/>
       ) : (
         <Fragment>
+          <PageHeader text="Dashboard" textCenter dataTestId="dashboardHeader" />
           <ActionsMenu {...actionsMenuProps} />
           <Tabs dataTestId="dashboardTabs">
             <Tabs.TabHeaders>

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -70,6 +70,12 @@ describe("<Dashboard />", () => {
     expect(getByText("Loading Dashboard for unitTestUser")).toBeDefined();
   });
 
+  it("should render the Dashboard header", () => {
+    const {getByTestId, getByText} = render(<Dashboard />, store);
+    expect(getByTestId("dashboardHeader")).toBeDefined();
+    expect(getByText("Dashboard")).toBeDefined();
+  });
+
   it("should render the dashboard actions menu", () => {
     const {getByTestId, getAllByText} = render(<Dashboard />, store);
     expect(getByTestId("dashboardActionsMenu")).toBeDefined();

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -70,9 +70,16 @@ describe("<Dashboard />", () => {
     expect(getByText("Loading Dashboard for unitTestUser")).toBeDefined();
   });
 
-  it("should render the dashboard action buttons", () => {
+  it("should render the dashboard actions menu", () => {
+    const {getByTestId, getAllByText} = render(<Dashboard />, store);
+    expect(getByTestId("dashboardActionsMenu")).toBeDefined();
+    expect(getAllByText("Actions")).toBeDefined();
+  });
+
+  it("should render the 'New Project' item under the actions menu", () => {
     const {getByTestId, getByText} = render(<Dashboard />, store);
-    expect(getByTestId("dashboardNewProject")).toBeDefined();
+    const actionsMenu = getByTestId("dashboardActionsMenu");
+    fireEvent.click(actionsMenu);
     expect(getByText("New Project")).toBeDefined();
   });
 
@@ -84,9 +91,10 @@ describe("<Dashboard />", () => {
   });
 
   it("should render the ProjectModal when the new project button is clicked", () => {
-    const {queryByTestId} = render(<Dashboard />, store);
-    const newProjectButton = queryByTestId("dashboardNewProject");
-    expect(newProjectButton).toBeDefined();
+    const {getByTestId, getByText, queryByTestId} = render(<Dashboard />, store);
+    const actionsMenu = getByTestId("dashboardActionsMenu");
+    fireEvent.click(actionsMenu);
+    const newProjectButton = getByText("New Project");
     expect(queryByTestId("projectModal.wrapper")).toBeNull();
     fireEvent.click(newProjectButton);
     expect(queryByTestId("projectModal.wrapper")).toBeDefined();

--- a/src/containers/dashboard/dashboard.styles.js
+++ b/src/containers/dashboard/dashboard.styles.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import {TabsWrapper} from "../../components/tabs/tabs.styles";
 import {Spinner} from "../../components/loading-spinner/loading-spinner.styles";
+import {ActionsWrapper} from "../../components/actions-menu/actions-menu.styles";
 
 export const DashboardWrapper = styled.div`
   position: relative;
@@ -15,5 +16,9 @@ export const DashboardWrapper = styled.div`
 
   & ${Spinner} {
     padding-top: 35px;
+  }
+
+  & ${ActionsWrapper} {
+    top: 100px;
   }
 `;

--- a/src/containers/dashboard/dashboard.styles.js
+++ b/src/containers/dashboard/dashboard.styles.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import {TabsWrapper} from "../../components/tabs/tabs.styles";
 import {Spinner} from "../../components/loading-spinner/loading-spinner.styles";
-import {ButtonWrapper} from "../../components/button/button.styles";
 
 export const DashboardWrapper = styled.div`
   position: relative;
@@ -16,20 +15,5 @@ export const DashboardWrapper = styled.div`
 
   & ${Spinner} {
     padding-top: 35px;
-  }
-`;
-
-export const DashboardActionButtons = styled.div`
-  position: absolute;
-  right: 50px;
-  top: 30px;
-  z-index: 2999;
-
-  & ${ButtonWrapper} {
-    display: inline-block;
-  }
-
-  & ${ButtonWrapper}:last-of-type {
-    margin-left: 5px;
   }
 `;

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -25,6 +25,7 @@ import ProjectModal from "../../components/project-modal/project-modal";
 import {push} from "connected-react-router";
 import {showNotification} from "../../store/actions/notification";
 import ActionsMenu from "../../components/actions-menu/actions-menu";
+import PageHeader from "../../components/page-header/page-header";
 
 const ProjectDetails = (props) => {
   // Extracting our props for use and declaring component states.
@@ -142,6 +143,7 @@ const ProjectDetails = (props) => {
         ) : 
         (
           <Fragment>
+            <PageHeader text={`Project - ${project.name}`} dataTestId="projectDetailsHeader" textCenter/>
             {userRoles && (userRoles.isAdmin || userRoles.isManager) && (
               <ActionsMenu {...actionsMenuProps} />
             )}

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -9,8 +9,7 @@ import {
   ProjectID,
   ProjectVisibility,
   ProjectDescription,
-  Statistic,
-  ProjectActionButtons
+  Statistic
 } from "./project-details.styles";
 import {getProject, updateProject, deleteProject} from "../../store/actions/project";
 import {getMemberships, deleteMembership, updateMembership, createMembership, getAvailableUsers} from "../../store/actions/membership";
@@ -22,10 +21,10 @@ import MembershipsTable from "../../components/memberships-table/memberships-tab
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import MembershipModal from "../../components/membership-modal/membership-modal";
 import { faTrash, faEdit, faUserTimes, faUserPlus } from "@fortawesome/free-solid-svg-icons";
-import Button from "../../components/button/button";
 import ProjectModal from "../../components/project-modal/project-modal";
 import {push} from "connected-react-router";
 import {showNotification} from "../../store/actions/notification";
+import ActionsMenu from "../../components/actions-menu/actions-menu";
 
 const ProjectDetails = (props) => {
   // Extracting our props for use and declaring component states.
@@ -113,6 +112,26 @@ const ProjectDetails = (props) => {
   
   const project = projectData && projectData.project;
   const userRoles = projectData && projectData.userRoles;
+  const actionsMenuProps = {
+    dataTestId: "projectDetailsActionsMenu",
+    menuItems: [{
+      icon: faEdit,
+      label: "Edit Project",
+      onClick: () => setShowProjectEditModal(true)
+    }, {
+      icon: faUserPlus,
+      label: "Add Member",
+      onClick: () => setShowAddMemberModal(true)
+    }]
+  };
+  if(userRoles && userRoles.isAdmin) {
+    actionsMenuProps.menuItems.push({
+      icon: faTrash,
+      label: "Delete Project",
+      onClick: () => setShowProjectDeleteModal(true)
+    });
+  }
+
   return (
     <ProjectDetailsWrapper>
       {pageError ? (
@@ -123,39 +142,9 @@ const ProjectDetails = (props) => {
         ) : 
         (
           <Fragment>
-            {userRoles && <ProjectActionButtons>
-              {userRoles.isAdmin && (
-                <Button
-                  small
-                  secondary
-                  danger
-                  label="Delete Project"
-                  startIcon={faTrash}
-                  dataTestId="detailsDeleteProject"
-                  onClick={() => setShowProjectDeleteModal(true)}
-                />
-              )}
-              {(userRoles.isManager || userRoles.isAdmin) && (
-                <Fragment>
-                  <Button
-                    small
-                    secondary
-                    label="Edit Project"
-                    startIcon={faEdit}
-                    dataTestId="detailsEditProject"
-                    onClick={() => setShowProjectEditModal(true)}
-                  />
-                  <Button
-                    small
-                    secondary
-                    label="Add Member"
-                    startIcon={faUserPlus}
-                    dataTestId="detailsNewMember"
-                    onClick={() => setShowAddMemberModal(true)}
-                  />
-                </Fragment>
-              )}
-            </ProjectActionButtons>}
+            {userRoles && (userRoles.isAdmin || userRoles.isManager) && (
+              <ActionsMenu {...actionsMenuProps} />
+            )}
             <Tabs dataTestId="projectDetailsTabs">
               <Tabs.TabHeaders>
                 <Tabs.Header>Details</Tabs.Header>

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -111,6 +111,14 @@ describe("<ProjectDetails />", () => {
     expect(getByText("Loading project details")).toBeDefined();
   });
 
+  it("should render the project details page header", async() => {
+    const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("projectDetailsHeader")).toBeDefined();
+    expect(getByText(`Project - Unit Test Project`)).toBeDefined();
+
+  });
+
   it("should render the project details, members, and backlog tabs", async() => {
     const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -250,85 +250,93 @@ describe("<ProjectDetails />", () => {
     expect(queryByTestId("membershipModal.wrapper")).toBeDefined();
   });
 
-  it("should render the 'Delete Project' button if the user has admin permissions", async() => {
+  it("should render the actions menu component for admins/managers", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(getByTestId("detailsDeleteProject")).toBeDefined();
-    expect(getByText("Delete Project")).toBeDefined();
+    expect(getByTestId("projectDetailsActionsMenu")).toBeDefined();
+    expect(getByText("Actions")).toBeDefined();
   });
 
-  it("should not render the 'Delete Project' button if the user has non-admin permissions", async() => {
+  it("should not render the actions menu component for developers/viewers", async() => {
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isDeveloper: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(queryByTestId("detailsDeleteProject")).toBeNull();
+    expect(queryByTestId("projectDetailsActionsMenu")).toBeNull();
+    expect(queryByText("Actions")).toBeNull();
+  });
+  
+  it("should render the 'Delete Project' action if the user has admin permissions", async() => {
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    expect(getByText("Delete Project")).toBeDefined();
+  });
+
+  it("should not render the 'Delete Project' action if the user has non-admin permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    const {queryByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
     expect(queryByText("Delete Project")).toBeNull();
   });
 
   it("should render the delete project modal when 'Delete Project' is clicked", async() => {
-    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    const deleteButton = getByTestId("detailsDeleteProject");
-    fireEvent.click(deleteButton);
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    const deleteItem = getByText("Delete Project");
+    fireEvent.click(deleteItem);
     expect(getByTestId("projectDeleteModal.wrapper")).toBeDefined();
   });
 
-  it("should render the 'Edit Project' button if the user has admin/manager permissions", async() => {
+  it("should render the 'Edit Project' action if the user has admin/manager permissions", async() => {
     store.dispatch = jest.fn();
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(getByTestId("detailsEditProject")).toBeDefined();
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
     expect(getByText("Edit Project")).toBeDefined();
   });
 
-  it("should not render the 'Edit Project' button if the user has insufficient permissions", async() => {
-    store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isDeveloper: true}}));
-    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
-    const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(queryByTestId("detailsEditProject")).toBeNull();
-    expect(queryByText("Edit Project")).toBeNull();
-  });
-
   it("should render the edit project modal when 'Edit Project' is clicked", async() => {
-    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    const editButton = getByTestId("detailsEditProject");
-    fireEvent.click(editButton);
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    const editItem = getByText("Edit Project");
+    fireEvent.click(editItem);
     expect(getByTestId("projectModal.wrapper")).toBeDefined();
   });
 
-  it("should render the 'Add Member' button if the user has admin/manager permissions", async() => {
+
+  it("should render the 'Add Member' action if the user has admin/manager permissions", async() => {
     store.dispatch = jest.fn();
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(getByTestId("detailsNewMember")).toBeDefined();
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
     expect(getByText("Add Member")).toBeDefined();
-  });
-
-  it("should not render the 'Add Member' button if the user has insufficient permissions", async() => {
-    store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isDeveloper: true}}));
-    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
-    const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(queryByTestId("detailsNewMember")).toBeNull();
-    expect(queryByText("Add Member")).toBeNull();
   });
 
   it("should render the add member modal when 'Add Member' is clicked", async() => {
     store.dispatch.mockReturnValueOnce({users: []});
-    const {getByTestId} = render(<ProjectDetails {...props} />, store);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    const addMemberButton = getByTestId("detailsNewMember");
-    fireEvent.click(addMemberButton);
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    const editItem = getByText("Add Member");
+    fireEvent.click(editItem);
     expect(getByTestId("membershipModal.wrapper")).toBeDefined();
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });

--- a/src/containers/project-details/project-details.styles.js
+++ b/src/containers/project-details/project-details.styles.js
@@ -6,12 +6,14 @@ import {
   black,
   black80,
   primaryBlue,
-  primaryGreen
+  primaryGreen,
+  pageHeaderHeight
 } from "../../common-styles/variables";
+import {ActionsWrapper} from "../../components/actions-menu/actions-menu.styles";
 
 export const ProjectDetailsWrapper = styled.div`
   position: relative;
-  height: 100%;
+  height: calc(100% - ${pageHeaderHeight});
   width: 100%;
 
   & ${TabsWrapper} {
@@ -23,6 +25,10 @@ export const ProjectDetailsWrapper = styled.div`
 
   & ${Spinner} {
     padding-top: 35px;
+  }
+
+  & ${ActionsWrapper} {
+    top: 100px;
   }
 `;
 
@@ -76,6 +82,10 @@ export const ProjectID = styled.small`
 
 export const ProjectName = styled.h1`
   margin: 0 0 5px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 655px;
 `;
 
 export const ProjectVisibility = styled.div`

--- a/src/containers/project-details/project-details.styles.js
+++ b/src/containers/project-details/project-details.styles.js
@@ -8,7 +8,6 @@ import {
   primaryBlue,
   primaryGreen
 } from "../../common-styles/variables";
-import {ButtonWrapper} from "../../components/button/button.styles";
 
 export const ProjectDetailsWrapper = styled.div`
   position: relative;
@@ -139,24 +138,5 @@ export const Statistic = styled.div`
   &:hover span {
     color: ${black};
     border-color: ${black};
-  }
-`;
-
-export const ProjectActionButtons = styled.div`
-  position: absolute;
-  right: 50px;
-  top: 30px;
-  z-index: 2999;
-
-  & ${ButtonWrapper} {
-    display: inline-block;
-  }
-
-  & ${ButtonWrapper} {
-    margin-left: 5px;
-  }
-
-  & ${ButtonWrapper}:first-of-type {
-    margin-left: 0;
   }
 `;


### PR DESCRIPTION
This PR contains:
- Added generic ActionsMenu component to be reused on various pages. added unit tests.
- Implemented `ActionsMenu` on `ProjectDetails` and updated tests.
- Update `Table` css for highlighting allowed `Actions`
- Updated `DashboardProjectsTable` and `MembershipsTable` to account for new Table changes.
- Implemented `ActionsMenu` on `Dashboard` and updated tests.
- Added new `TableValue` styled component to be used in Tables.
- Implemented TableValue component on Dashboard/Membership tables.
- Various style updates to account for project/users with very long names.
- Implemented `PageHeader` on `Dashboard` and added unit tests.
- Implemented `PageHeader` on `ProjectDetails` and added unit tests.