### PR TITLE
Dashboard Update

### DIFF
--- a/src/components/dashboard-projects-table/dashboard-projects-table.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.jsx
@@ -6,9 +6,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faArrowRight, faTrash, faBook, faUserPlus} from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "../tooltip/tooltip";
 import {formatDate, getPermissionLevel} from "../../utils";
-import {ActionsWrapper, Action} from "../table/table.styles";
+import {ActionsWrapper, Action, PaginationSection} from "../table/table.styles";
+import {DashboardProjectsTableWrapper} from "./dashboard-projects-table.styles";
+import Pagination from "../pagination/pagination";
 
-const DashboardProjectsTable = ({projects, actions}) => {
+const DashboardProjectsTable = ({projects, actions, pagination}) => {
   const _renderActions = (row) => {
     const {deleteProject, addStory, addMember, viewProject} = actions;
     const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
@@ -68,8 +70,23 @@ const DashboardProjectsTable = ({projects, actions}) => {
     rows: projects
   };
 
+  const paginationProps = {
+    dataTestId: "dashboardProjectsPagination",
+    itemsPerPage: pagination && pagination.itemsPerPage,
+    page: pagination && pagination.page,
+    totalPages: pagination && pagination.totalPages,
+    onPageClick: (page) => pagination && pagination.getPage(page)
+  };
+
   return (
-    <Table {...tableProps} />
+    <DashboardProjectsTableWrapper>
+      <Table {...tableProps} />
+      {pagination && (
+        <PaginationSection>
+          <Pagination {...paginationProps} />
+        </PaginationSection>
+      )}
+    </DashboardProjectsTableWrapper>
   );
 };
 
@@ -80,7 +97,13 @@ DashboardProjectsTable.propTypes = {
     addMember: PropTypes.func.isRequired,
     addStory: PropTypes.func.isRequired,
     viewProject: PropTypes.func.isRequired
-  }).isRequired
+  }).isRequired,
+  pagination: PropTypes.shape({
+    page: PropTypes.number.isRequired,
+    totalPages: PropTypes.number.isRequired,
+    itemsPerPage: PropTypes.number.isRequired,
+    getPage: PropTypes.func.isRequired
+  })
 };
 
 export default DashboardProjectsTable;

--- a/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.spec.jsx
@@ -30,6 +30,12 @@ describe("<DashboardProjectsTable />", () => {
         addMember: jest.fn(),
         addStory: jest.fn(),
         viewProject: jest.fn()
+      },
+      pagination: {
+        page: 1,
+        totalPages: 5,
+        itemsPerPage: 10,
+        getPage: jest.fn()
       }
     };
   });
@@ -98,5 +104,17 @@ describe("<DashboardProjectsTable />", () => {
     expect(getAllByText("Add Story")).toHaveLength(2);
     expect(getAllByText("Add Member")).toHaveLength(1);
     expect(getAllByText("View Project")).toHaveLength(2);
+  });
+
+  it("should render the pagination component", () => {
+    const {getByTestId} = render(<DashboardProjectsTable {...props}/>);
+    expect(getByTestId("dashboardProjectsPagination")).toBeDefined();
+  });
+
+  it("should call the getPage method when paginating", () => {
+    const {getByTestId} = render(<DashboardProjectsTable {...props}/>);
+    const nextPage = getByTestId("dashboardProjectsPagination.next");
+    fireEvent.click(nextPage);
+    expect(props.pagination.getPage).toHaveBeenCalledWith(2);
   });
 });

--- a/src/components/dashboard-projects-table/dashboard-projects-table.styles.js
+++ b/src/components/dashboard-projects-table/dashboard-projects-table.styles.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import {TableWrapper} from "../table/table.styles";
+import {PaginationWrapper} from "../pagination/pagination.styles";
+import {white, black1a} from "../../common-styles/variables";
+
+export const DashboardProjectsTableWrapper = styled.div`
+  position: relative;
+  height: 775px;
+  background-color: ${black1a};
+
+  & ${TableWrapper} {
+    background-color: ${white};
+  }
+
+  & ${PaginationWrapper} {
+    position: relative;
+    margin-top: 25px;
+  }
+`;

--- a/src/components/memberships-table/memberships-table.jsx
+++ b/src/components/memberships-table/memberships-table.jsx
@@ -5,8 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faUserTimes, faUserEdit} from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "../tooltip/tooltip";
 import {formatDate, getPermissionLevel} from "../../utils";
-import {ActionsWrapper, Action} from "../table/table.styles";
-import {MembershipsTableWrapper, PaginationSection} from "./memberships-table.styles";
+import {ActionsWrapper, Action, PaginationSection} from "../table/table.styles";
+import {MembershipsTableWrapper} from "./memberships-table.styles";
 import Pagination from "../pagination/pagination";
 import {TableValue} from "../table/table.styles";
 

--- a/src/components/memberships-table/memberships-table.styles.js
+++ b/src/components/memberships-table/memberships-table.styles.js
@@ -17,13 +17,3 @@ export const MembershipsTableWrapper = styled.div`
     margin-top: 25px;
   }
 `;
-
-export const PaginationSection = styled.div`
-  position: absolute;
-  width: 100%;
-  bottom: 0;
-  left: 0;
-  overflow: hidden;
-  text-align: center;
-  background-color: ${white};
-`;

--- a/src/components/table/table.styles.js
+++ b/src/components/table/table.styles.js
@@ -1,5 +1,6 @@
 import styled, {css} from "styled-components";
 import {
+  white,
   black,
   black80,
   black33,
@@ -86,4 +87,14 @@ export const TableWrapper = styled.div`
       border-bottom: 1px solid ${black80};
     }
   }
+`;
+
+export const PaginationSection = styled.div`
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  text-align: center;
+  background-color: ${white};
 `;

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -80,6 +80,18 @@ const Dashboard = (props) => {
       addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
       viewProject: (project) => historyPush(`/projects/${project.id}`),
       addStory: (project) => setNewStoryData({project})
+    },
+    pagination: {
+      itemsPerPage: projectsData && projectsData.itemsPerPage,
+      page: projectsData && projectsData.page,
+      totalPages: projectsData && projectsData.totalPages,
+      getPage: async(page) => {
+        if(page === projectsData.page)
+          return;
+        const response = await getDashboardProjects(page, projectsData.itemsPerPage);
+        if(!response.error)
+          return setProjectsData(response);
+      }
     }
   };
 

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -4,7 +4,6 @@ import {connect} from "react-redux";
 import {DashboardWrapper} from "./dashboard.styles";
 import Tabs from "../../components/tabs/tabs";
 import {showNotification} from "../../store/actions/notification";
-import {getDashboard} from "../../store/actions/dashboard";
 import {createProject, deleteProject} from "../../store/actions/project";
 import {createStory} from "../../store/actions/story";
 import {getAvailableUsers, createMembership, getMemberNames} from "../../store/actions/membership";
@@ -18,11 +17,12 @@ import MembershipModal from "../../components/membership-modal/membership-modal"
 import ActionsMenu from "../../components/actions-menu/actions-menu";
 import PageHeader from "../../components/page-header/page-header";
 import StoryModal from "../../components/story-modal/story-modal";
+import {getDashboardProjects, getDashboardStories} from "../../store/actions/dashboard";
 
 const Dashboard = (props) => {
   const {
-    getDashboard,
-    isLoading,
+    getDashboardProjects,
+    getDashboardStories,
     userInfo,
     showNotification,
     projectRequestInProgress,
@@ -30,7 +30,6 @@ const Dashboard = (props) => {
     storyRequestInProgress,
     createProject,
     deleteProject,
-    projects,
     historyPush,
     getAvailableUsers,
     createMembership,
@@ -41,11 +40,39 @@ const Dashboard = (props) => {
   const [deleteProjectData, setDeleteProject] = useState({});
   const [membershipData, setMembershipData] = useState({});
   const [newStoryData, setNewStoryData] = useState({});
+  const [projectsData, setProjectsData] = useState(undefined);
+  const [storiesData, setStoriesData] = useState(undefined);
 
+  // called once, after the component is mounted.
+  const _loadData = async() => {
+    const projectsResponse = await getDashboardProjects();
+    const storiesResponse = await getDashboardStories();
+    if(!projectsResponse.error)
+      setProjectsData(projectsResponse);
+    
+    if(!storiesResponse.error)
+      setStoriesData(storiesResponse);
+  };
   useEffect(() => {
-    getDashboard();
+    _loadData();
   }, []);
 
+  const _refreshProjects = async() => {
+    const {page, itemsPerPage} = projectsData;
+    const projectsResponse = await getDashboardProjects(page, itemsPerPage);
+    if(!projectsResponse.error)
+      setProjectsData(projectsResponse);
+  };
+
+  const _refreshStories = async() => {
+    const {page, itemsPerPage} = storiesData;
+    const storiesResponse = await getDashboardStories(page, itemsPerPage);
+    if(!storiesResponse.error)
+      setStoriesData(storiesResponse);
+  };
+
+  const projects = projectsData && projectsData.projects;
+  const stories = storiesData && storiesData.stories;
   const projectsTableProps = {
     projects,
     actions: {
@@ -67,7 +94,7 @@ const Dashboard = (props) => {
 
   return (
     <DashboardWrapper>
-      {isLoading ? (
+      {!projects || !stories ? (
         <LoadingSpinner alignCenter dataTestId="dashboardLoader" message={`Loading Dashboard for ${userInfo.displayName}`}/>
       ) : (
         <Fragment>
@@ -98,7 +125,7 @@ const Dashboard = (props) => {
               onSubmit={createProject}
               showNotification={showNotification}
               requestInProgress={projectRequestInProgress}
-              refresh={getDashboard}
+              refresh={_refreshProjects}
             />
           )}
           {membershipData.project && (
@@ -126,7 +153,7 @@ const Dashboard = (props) => {
                 label: "Project Name",
                 placeholder: "Enter the project's name"
               }}
-              refresh={getDashboard}
+              refresh={_refreshProjects}
             />
           )}
           {newStoryData.project && (
@@ -137,7 +164,7 @@ const Dashboard = (props) => {
               showNotification={showNotification}
               getMemberNames={getMemberNames}
               project={newStoryData.project}
-              refresh={getDashboard}
+              refresh={_refreshStories}
             />
           )}
         </Fragment>
@@ -147,10 +174,9 @@ const Dashboard = (props) => {
 };
 
 Dashboard.propTypes = {
+  getDashboardProjects: PropTypes.func.isRequired,
+  getDashboardStories: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  projects: PropTypes.array.isRequired,
-  stories: PropTypes.array.isRequired,
-  getDashboard: PropTypes.func.isRequired,
   projectRequestInProgress: PropTypes.bool.isRequired,
   membershipRequestInProgress: PropTypes.bool.isRequired,
   storyRequestInProgress: PropTypes.bool.isRequired,
@@ -166,14 +192,11 @@ Dashboard.propTypes = {
 
 export default connect((state) => ({
   isLoading: state.dashboard.isLoading,
-  projects: state.dashboard.projects,
-  stories: state.dashboard.stories,
   userInfo: state.auth.user,
   projectRequestInProgress: state.project.isLoading,
   membershipRequestInProgress: state.membership.isLoading,
   storyRequestInProgress: state.story.isLoading
 }), {
-  getDashboard,
   showNotification,
   createProject,
   deleteProject,
@@ -181,5 +204,7 @@ export default connect((state) => ({
   getAvailableUsers,
   createMembership,
   getMemberNames,
-  createStory
+  createStory,
+  getDashboardProjects,
+  getDashboardStories
 })(Dashboard);

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -5,21 +5,52 @@ import {waitFor, fireEvent} from "@testing-library/react";
 
 describe("<Dashboard />", () => {
   let store;
+  const projectsResponse = {
+    page: 1,
+    totalPages: 1,
+    itemsPerPage: 10,
+    projects: [{
+      id: "testProject1",
+      name: "Some Name",
+      isPrivate: true,
+      createdOn: "2020-08-01T19:08:37.237Z",
+      roles: {
+        isAdmin: true
+      }
+    },{
+      id: "testProject2",
+      name: "Another Name",
+      isPrivate: false,
+      createdOn: "2020-08-05T12:00:37.237Z",
+      roles: {
+        isDeveloper: true
+      }
+    }]
+  };
+  const storiesResponse = {
+    page: 1,
+    totalPages: 1,
+    itemsPerPages: 10,
+    stories: [{
+      id: "testStory1",
+      name: "test story",
+      creator: {displayName: "testUser1"},
+      owner: {displayName: "testUser55"}
+    },{
+      id: "testStory2",
+      name: "test story 2",
+      creator: {displayName: "testUser1"}
+    },{
+      id: "testStory3",
+      name: "test story 3",
+      creator: {displayName: "testUser123"},
+      owner: {displayName: "testUser1"}
+    }]
+  };
   beforeEach(() => {
     store = mockStore({
       dashboard: {
-        isLoading: false,
-        projects: [{
-          id: "some-id",
-          name: "Test Project",
-          description: "",
-          isPrivate: true,
-          roles: {
-            isAdmin: true
-          },
-          createdOn: new Date().toISOString()
-        }],
-        stories: []
+        isLoading: false
       },
       auth: {
         user: {
@@ -36,74 +67,67 @@ describe("<Dashboard />", () => {
         isLoading: false
       }
     });
+
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(projectsResponse);
+    store.dispatch.mockReturnValueOnce(storiesResponse);
   });
 
-  it("should mount the component", () => {
+  it("should mount the component", async() => {
     const component = render(<Dashboard />, store);
     expect(component).toBeDefined();
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
   });
 
-  it("should call props.getDashboard on component mount", async() => {
-    render(<Dashboard />, store);
-    await waitFor(() => expect(store.getActions()).toHaveLength(2));
-    expect(store.getActions()[0]).toEqual({type: "DASHBOARD_REQUEST_START"});
+  it("should call getDashboardProjects and getDashboardStories on component mount", async() => {
+    const component = render(<Dashboard />, store);
+    expect(component).toBeDefined();
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
   });
 
-  it("should render the loading spinner when awaiting API data", () => {
-    store = mockStore({
-      dashboard: {
-        isLoading: true,
-        stories: [],
-        projects: []
-      },
-      auth: {
-        user: {
-          displayName: "unitTestUser"
-        }
-      },
-      project: {
-        isLoading: false
-      },
-      membership: {
-        isLoading: false
-      },
-      story: {
-        isLoading: false
-      }
-    });
+  it("should render the loading spinner when awaiting API data", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce({});
+    store.dispatch.mockReturnValueOnce({});
     const {getByTestId, getByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("dashboardLoader")).toBeDefined();
     expect(getByText("Loading Dashboard for unitTestUser")).toBeDefined();
   });
 
-  it("should render the Dashboard header", () => {
+  it("should render the Dashboard header", async() => {
     const {getByTestId, getByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("dashboardHeader")).toBeDefined();
     expect(getByText("Dashboard")).toBeDefined();
   });
 
-  it("should render the dashboard actions menu", () => {
+  it("should render the dashboard actions menu", async() => {
     const {getByTestId, getAllByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("dashboardActionsMenu")).toBeDefined();
     expect(getAllByText("Actions")).toBeDefined();
   });
 
-  it("should render the 'New Project' item under the actions menu", () => {
+  it("should render the 'New Project' item under the actions menu", async() => {
     const {getByTestId, getByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     const actionsMenu = getByTestId("dashboardActionsMenu");
     fireEvent.click(actionsMenu);
     expect(getByText("New Project")).toBeDefined();
   });
 
-  it("should render the tabs component", () => {
+  it("should render the tabs component", async() => {
     const {getByTestId, getByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("dashboardTabs")).toBeDefined();
     expect(getByText("My Projects")).toBeDefined();
     expect(getByText("My Stories")).toBeDefined();
   });
 
-  it("should render the ProjectModal when the new project button is clicked", () => {
+  it("should render the ProjectModal when the new project button is clicked", async() => {
     const {getByTestId, getByText, queryByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     const actionsMenu = getByTestId("dashboardActionsMenu");
     fireEvent.click(actionsMenu);
     const newProjectButton = getByText("New Project");
@@ -112,77 +136,62 @@ describe("<Dashboard />", () => {
     expect(queryByTestId("projectModal.wrapper")).toBeDefined();
   });
 
-  it("should render a message is there are no projects to display", () => {
-    store = mockStore({
-      dashboard: {
-        isLoading: false,
-        stories: [],
-        projects: []
-      },
-      auth: {
-        user: {
-          displayName: "unitTestUser"
-        }
-      },
-      project: {
-        isLoading: false
-      },
-      membership: {
-        isLoading: false
-      },
-      story: {
-        isLoading: false
-      }
-    });
+  it("should render a message is there are no projects to display", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce({...projectsResponse, projects: []});
+    store.dispatch.mockReturnValueOnce(storiesResponse);
     const {getByText} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByText("You are not a member of any projects")).toBeDefined();
   });
 
-  it("should render the projects table if there are projects to display", () => {
+  it("should render the projects table if there are projects to display", async() => {
     const {getByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     expect(getByTestId("dashboardProjects")).toBeDefined();
   });
 
-  it("should render the DeleteModal if the delete project action is clicked", () => {
-    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
-    const deleteButton = getByTestId("action.deleteProject");
+  it("should render the DeleteModal if the delete project action is clicked", async() => {
+    const {getAllByTestId, queryByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const deleteButton = getAllByTestId("action.deleteProject")[0];
     expect(queryByTestId("projectDeleteModal.wrapper")).toBeNull();
     fireEvent.click(deleteButton);
     expect(queryByTestId("projectDeleteModal.wrapper")).toBeDefined();
   });
 
   it("should render the MembershipModal if the add member action is clicked", async() => {
-    store.dispatch = jest.fn().mockReturnValue({});
-    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
-    const addMemberButton = getByTestId("action.addMember");
+    const {getAllByTestId, queryByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    store.dispatch.mockReturnValueOnce({}); // mock get available members API response.
+    const addMemberButton = getAllByTestId("action.addMember")[0];
     expect(queryByTestId("membershipModal.wrapper")).toBeNull();
     fireEvent.click(addMemberButton);
     expect(queryByTestId("membershipModal.wrapper")).toBeDefined();
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });
 
   it("should render the StoryModal if the new story action is clicked", async() => {
-    store.dispatch = jest.fn().mockReturnValue({});
-    const {getByTestId, queryByTestId} = render(<Dashboard />, store);
-    const addStoryButton = getByTestId("action.addStory");
+    const {getAllByTestId, queryByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    store.dispatch.mockReturnValueOnce({});
+    const addStoryButton = getAllByTestId("action.addStory")[0];
     expect(queryByTestId("storyModal.wrapper")).toBeNull();
     fireEvent.click(addStoryButton);
     expect(queryByTestId("storyModal.wrapper")).toBeDefined();
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });
 
   it("should call the push redux action when the view project action is clicked", async() => {
-    store.dispatch = jest.fn();
-    const {getByTestId} = render(<Dashboard />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalled());
-    const viewButton = getByTestId("action.viewProject");
-    fireEvent.mouseOver(viewButton);
+    const {getAllByTestId} = render(<Dashboard />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const viewButton = getAllByTestId("action.viewProject")[0];
     fireEvent.click(viewButton);
     expect(store.dispatch).toHaveBeenLastCalledWith({
       type: "@@router/CALL_HISTORY_METHOD",
       payload: {
         method: "push",
-        args: [`/projects/${store.getState().dashboard.projects[0].id}`]
+        args: [`/projects/${projectsResponse.projects[0].id}`]
       }
     });
   });

--- a/src/store/actions/dashboard.js
+++ b/src/store/actions/dashboard.js
@@ -6,9 +6,26 @@ import {
 } from "../types/dashboard";
 const apiRoute = "/api/dashboard";
 
-export const getDashboard = () => dispatch => {
+export const getDashboardProjects = (page, itemsPerPage) => dispatch => {
+  const queryString = {};
+  if(page)
+    queryString.page = page;
+  if(itemsPerPage)
+    queryString.itemsPerPage = itemsPerPage;
   return dispatch({
     types: [DASHBOARD_REQUEST_START, DASHBOARD_REQUEST_SUCCESS, DASHBOARD_REQUEST_FAILURE],
-    request: request.get(apiRoute)
+    request: request.get(`${apiRoute}/projects`).query(queryString)
+  });
+};
+
+export const getDashboardStories = (page, itemsPerPage) => dispatch => {
+  const queryString = {};
+  if(page)
+    queryString.page = page;
+  if(itemsPerPage)
+    queryString.itemsPerPage = itemsPerPage;
+  return dispatch({
+    types: [DASHBOARD_REQUEST_START, DASHBOARD_REQUEST_SUCCESS, DASHBOARD_REQUEST_FAILURE],
+    request: request.get(`${apiRoute}/stories`).query(queryString)
   });
 };

--- a/src/store/reducers/dashboard/dashboard.spec.js
+++ b/src/store/reducers/dashboard/dashboard.spec.js
@@ -1,5 +1,5 @@
 import dashboardReducer from "./dashboard";
-import {getDashboard} from "../../actions/dashboard";
+import {getDashboardProjects, getDashboardStories} from "../../actions/dashboard";
 import {mockStore} from "../../../test-utils";
 import { waitFor } from "@testing-library/react";
 
@@ -81,13 +81,18 @@ describe("Dashboard Reducer / Actions", () => {
     });
   });
 
-  it("should dispatch a redux API call to get dashboard data", async () => {
-    store.dispatch(getDashboard());
+  it("should dispatch a redux API call to get dashboard projects data", async () => {
+    store.dispatch(getDashboardProjects());
     await waitFor(() => expect(store.getActions()).toHaveLength(2));
-    // First action should be the REQUEST
     expect(store.getActions()[0].type).toBe("DASHBOARD_REQUEST_START");
+    const expectedTypes = ["DASHBOARD_REQUEST_SUCCESS", "DASHBOARD_REQUEST_FAILURE"];
+    expect(expectedTypes.indexOf(store.getActions()[1].type)).toBeTruthy();
+  });
 
-    // Second action is expected to be SUCCESS or FAILURE
+  it("should dispatch a redux API call to get dashboard stories data", async () => {
+    store.dispatch(getDashboardStories());
+    await waitFor(() => expect(store.getActions()).toHaveLength(2));
+    expect(store.getActions()[0].type).toBe("DASHBOARD_REQUEST_START");
     const expectedTypes = ["DASHBOARD_REQUEST_SUCCESS", "DASHBOARD_REQUEST_FAILURE"];
     expect(expectedTypes.indexOf(store.getActions()[1].type)).toBeTruthy();
   });


### PR DESCRIPTION
The API endpoints for retrieving dashboard data have been split into two and paginated. This PR implements those changes on the front end. PR contains:
- Update `DashboardProjectsTable` to support pagination. Added unit tests.
- Made `PaginationSection` a part of Table styles. Update `MembershipModal` imports.
- Added `getDashboardProjects` and `getDashboardStories` redux actions and tests.
- Updated `Dashboard`:
  * rendering and mount logic, utilizing the new API endpoints.
  * updated component flow to be similar to `ProjectDetails`.
  * added logic to pass dashboard projects Pagination data to the ProjectsTable.
  * updated all unit tests.