### PR TITLE
Add query-string tracking to ProjectDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Compass
-React UI for agile project backlog management
+React UI for agile project backlog management.
+
+## Required Dependencies
+
+The following dependencies are required:
+
+### 1. [Needle API](https://github.com/zackdavis88/needle)
 
 ## Required Configuration
 
@@ -12,10 +18,29 @@ equivalent Windows commands will have to be researched on your own.*
 This step may be completed by providing a CA signed certificate, assuming 
 you have the .pem files, or by generating a self-signed certificate 
 as shown below:
-
 ```
 mkdir -p compass/config/ssl
 cd compass/config/ssl
 openssl req -x509 -nodes -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365
 ```
 *You will be asked questions when generating the self-signed certificate, answer the prompts until the process completes*
+
+### 2. Install Node Modules
+Run the following command from the _root of the cloned repository_ to
+install node modules required for the UI.
+```
+npm install
+```
+
+## Start Up
+**_After all Install Dependencies and Required Configuration steps have been completed, use the following command
+to start the API._**
+```
+npm run start
+```
+
+## Test Suite
+Compass comes with a suite of component tests that can be ran using the following command:
+```
+npm run test
+```

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -93,6 +93,9 @@ describe("<ProjectDetails />", () => {
         params: {
           projectId: "testProjectId"
         }
+      },
+      location: {
+        search: ""
       }
     };
     store = mockStore({
@@ -120,7 +123,7 @@ describe("<ProjectDetails />", () => {
   it("should mount the component", async() => {
     const component = render(<ProjectDetails {...props} />, store);
     expect(component).toBeDefined();
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalled());
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });
 
   it("should render the loading spinner when awaiting API data", async() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,5 +26,47 @@ export const getPermissionLevel = (roles) => {
     return "Viewer";
 
   return "None";
-    
+};
+
+// Taken from stackoverflow: https://stackoverflow.com/questions/5999118/how-can-i-add-or-update-a-query-string-parameter
+export const generateUrlWithQuery = (key, value, url) => {
+  if (!url) url = window.location.href;
+  var re = new RegExp("([?&])" + key + "=.*?(&|#|$)(.*)", "gi"),
+      hash;
+
+  if (re.test(url)) {
+      if (typeof value !== 'undefined' && value !== null) {
+          return url.replace(re, '$1' + key + "=" + value + '$2$3');
+      } 
+      else {
+          hash = url.split('#');
+          url = hash[0].replace(re, '$1$3').replace(/(&|\?)$/, '');
+          if (typeof hash[1] !== 'undefined' && hash[1] !== null) {
+              url += '#' + hash[1];
+          }
+          return url;
+      }
+  }
+  else {
+      if (typeof value !== 'undefined' && value !== null) {
+          var separator = url.indexOf('?') !== -1 ? '&' : '?';
+          hash = url.split('#');
+          url = hash[0] + separator + key + '=' + value;
+          if (typeof hash[1] !== 'undefined' && hash[1] !== null) {
+              url += '#' + hash[1];
+          }
+          return url;
+      }
+      else {
+          return url;
+      }
+  }
+}
+
+// Also ripped from stackoverflow: https://stackoverflow.com/questions/8648892/how-to-convert-url-parameters-to-a-javascript-object
+export const generateObjectFromSearch = (searchString) => {
+  if(!searchString)
+    return {};
+  const search = searchString.substring(1);
+  return JSON.parse('{"' + search.replace(/&/g, '","').replace(/=/g,'":"') + '"}', function(key, value) { return key===""?value:decodeURIComponent(value)})
 };


### PR DESCRIPTION
This PR contains:
- Added query-string tracking to `ProjectDetails`. When a new page is clicked, we will append a query string. When the component mounts we check for the query-string and fetch the appropriate data based on the query-string page value we have.
- Updated unit tests for `ProjectDetails`
- Fixed major bug on `ProjectDetails` MembershipsTable...not sure how this happened but a prop name got changed, it has been reverted.
- Updated README