### PR TITLE
Add story filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,9 +2492,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.9",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.9.tgz",
-      "integrity": "sha512-k4qFfJ5AUKrWok5KYXp2EPm89b0P/KZpl7Vg4XuOTVVQEhLDBDBU3iBFrjjdgd8fLw96aAtmnwhXHl63bWeBQQ==",
+      "version": "26.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.10.tgz",
+      "integrity": "sha512-i2m0oyh8w/Lum7wWK/YOZJakYF8Mx08UaKA1CtbmFeDquVhAEdA7znacsVSf2hJ1OQ/OfVMGN90pw/AtzF8s/Q==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -2857,9 +2857,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -3473,9 +3473,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-      "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true
     },
     "body-parser": {

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -6,9 +6,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 const SearchBar = (props) => {
-  const [inputValue, setInputValue] = useState(props.searchedValue || "");
   const [isFocused, setIsFocused] = useState(false);
-  const hasValue = !!inputValue;
+  const hasValue = !!props.value;
   const wrapperProps = {
     hasValue
   };
@@ -17,16 +16,16 @@ const SearchBar = (props) => {
     id: props.id,
     type: "text",
     placeholder: isFocused ? "" : props.placeholder,
-    value: inputValue,
+    value: props.value,
     onChange: (event) => {
-      setInputValue(event.target.value);
+      props.onChange(event.target.value);
     },
     onFocus: () => setIsFocused(true),
     onBlur: () => setIsFocused(false)
   };
 
   const searchButtonProps = {
-    onClick: () => props.searchedValue !== inputValue && props.search(inputValue),
+    onClick: () => props.searchedValue !== props.value && props.search(props.value),
     label: "Search",
     small: true,
     primary: true
@@ -34,7 +33,6 @@ const SearchBar = (props) => {
 
   const clearButtonProps = {
     onClick: () => {
-      setInputValue("");
       props.clear();
     }
   };
@@ -64,10 +62,12 @@ SearchBar.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
   searchedValue: PropTypes.string.isRequired,
   dataTestId: PropTypes.string,
   search: PropTypes.func.isRequired,
-  clear: PropTypes.func.isRequired
+  clear: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired
 };
 
 export default SearchBar;

--- a/src/components/search-bar/search-bar.spec.jsx
+++ b/src/components/search-bar/search-bar.spec.jsx
@@ -12,6 +12,8 @@ describe("<SearchBar />", () => {
       label: "Test Label",
       placeholder: "Test Placeholder",
       searchedValue: "",
+      value: "",
+      onChange: jest.fn(),
       search: jest.fn(),
       clear: jest.fn()
     };
@@ -41,13 +43,9 @@ describe("<SearchBar />", () => {
   });
 
   it("should render a label if the input has a value", () => {
+    props.value = "some value";
     const {getByLabelText, getByTestId} = render(<SearchBar {...props} />);
     const inputBox = getByTestId("testSearchBar.input");
-    fireEvent.change(inputBox, {
-      target: {
-        value: "some value"
-      }
-    });
     fireEvent.blur(inputBox);
     expect(getByLabelText("Test Label")).toBeDefined();
   });
@@ -57,14 +55,13 @@ describe("<SearchBar />", () => {
     expect(getByPlaceholderText("Test Placeholder")).toBeDefined();
   });
 
-  it("should update input box value on change", () => {
+  it("should call onChange prop when input is changed", () => {
     const {getByTestId} = render(<SearchBar {...props} />);
     const input = getByTestId("testSearchBar.input");
-    expect(input).toHaveValue("");
     fireEvent.change(input, {
       target: {value: "test value"}
     });
-    expect(input).toHaveValue("test value");
+    expect(props.onChange).toHaveBeenCalledWith("test value");
   });
 
   it("should not call the search method if searchedValue equals input value", () => {
@@ -75,12 +72,11 @@ describe("<SearchBar />", () => {
   });
 
   it("should call the search method if value does not equal searchedValue", () => {
+    props.value = "something";
     const {getByTestId} = render(<SearchBar {...props}/>);
     const searchButton = getByTestId("testSearchBar.search");
-    const input = getByTestId("testSearchBar.input");
-    fireEvent.change(input, {target: {value: "test value"}});
     fireEvent.click(searchButton);
-    expect(props.search).toHaveBeenCalledWith("test value");
+    expect(props.search).toHaveBeenCalledWith("something");
   });
 
   it("should not render the clear button if searchedValue is empty", () => {

--- a/src/components/stories-table/stories-table.jsx
+++ b/src/components/stories-table/stories-table.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Fragment} from "react";
 import PropTypes from "prop-types";
 import Table from "../table/table";
 import {TableValue} from "../table/table.styles";
@@ -11,6 +11,7 @@ import {StoriesTableWrapper} from "./stories-table.styles";
 import Pagination from "../pagination/pagination";
 
 const StoriesTable = ({stories, project, actions, pagination}) => {
+  const isEmpty = stories.length === 0;
   const _renderActions = (row) => {
     const {editStory, deleteStory, viewStory} = actions;
     const userRoles = project ? (project.userRoles || {}) : {};
@@ -84,12 +85,18 @@ const StoriesTable = ({stories, project, actions, pagination}) => {
   };
 
   return (
-    <StoriesTableWrapper>
-      <Table {...tableProps} />
-      {pagination && (
-        <PaginationSection>
-          <Pagination {...paginationProps} />
-        </PaginationSection>
+    <StoriesTableWrapper isEmpty={isEmpty}>
+      {!isEmpty ? (
+        <Fragment>
+          <Table {...tableProps} />
+          {pagination && (
+            <PaginationSection>
+              <Pagination {...paginationProps} />
+            </PaginationSection>
+          )}
+        </Fragment>
+      ) : (
+        <div>There are no stories to display</div>
       )}
     </StoriesTableWrapper>
   );

--- a/src/components/stories-table/stories-table.spec.jsx
+++ b/src/components/stories-table/stories-table.spec.jsx
@@ -50,6 +50,12 @@ describe("<StoriesTable />", () => {
     expect(component).toBeDefined();
   });
 
+  it("should render a message if there are no stories to display", () => {
+    props.stories = [];
+    const {getByText} = render(<StoriesTable {...props} />);
+    expect(getByText("There are no stories to display")).toBeDefined();
+  });
+
   it("should render the expected headers", () => {
     const {getByTestId, getByText} = render(<StoriesTable {...props}/>);
     expect(getByTestId("storiesTable")).toBeDefined();

--- a/src/components/stories-table/stories-table.styles.js
+++ b/src/components/stories-table/stories-table.styles.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, {css} from "styled-components";
 import {TableWrapper} from "../table/table.styles";
 import {PaginationWrapper} from "../pagination/pagination.styles";
 import {white, black1a} from "../../common-styles/variables";
@@ -7,6 +7,9 @@ export const StoriesTableWrapper = styled.div`
   position: relative;
   height: 775px;
   background-color: ${black1a};
+  ${({isEmpty}) => isEmpty && css`
+    background-color: ${white};
+  `}
 
   & ${TableWrapper} {
     background-color: ${white};

--- a/src/components/tabs/tabs.jsx
+++ b/src/components/tabs/tabs.jsx
@@ -8,13 +8,13 @@ import {
   PanelWrapper
 } from "./tabs.styles";
 
-const Tabs = ({dataTestId, children}) => {
-  const [activeTab, setActiveTab] = useState(0);
+const Tabs = ({dataTestId, children, tabOverride, onHeaderClick}) => {
+  const [activeTab, setActiveTab] = useState(Number(tabOverride) || 0);
   return (
     <TabsWrapper data-testid={dataTestId}>
       {children && Array.isArray(children) && children.reduce((prev, curr, index) => {
         if(curr.type === TabHeaders)
-          return prev.concat(cloneElement(curr, {key: index, dataTestId, setActiveTab, activeTab}));
+          return prev.concat(cloneElement(curr, {key: index, dataTestId, setActiveTab, activeTab, onHeaderClick}));
         
         if(curr.type === TabPanels)
           return prev.concat(cloneElement(curr, {key: index, dataTestId, activeTab}));
@@ -25,14 +25,23 @@ const Tabs = ({dataTestId, children}) => {
   );
 };
 
-const TabHeaders = ({dataTestId, setActiveTab, children, activeTab}) => {
+const TabHeaders = ({dataTestId, setActiveTab, children, activeTab, onHeaderClick}) => {
   const _renderTabHeaders = () => {
     if(children && !Array.isArray(children) && children.type === TabHeader)
       return cloneElement(children, {dataTestId, setActiveTab: () => setActiveTab(0), tabIsActive: 1});
 
     if(children && Array.isArray(children))
       return children.reduce((prev, curr, index) => curr.type === TabHeader ? prev.concat(
-        cloneElement(curr, {key: index, dataTestId, setActiveTab: () => setActiveTab(index), tabIsActive: index === activeTab})
+        cloneElement(curr, {
+          key: index, 
+          dataTestId, 
+          setActiveTab: () => {
+            if(onHeaderClick)
+              onHeaderClick(index);
+            setActiveTab(index);
+          }, 
+          tabIsActive: index === activeTab
+        })
       ) : prev, []);
     return children;
   };
@@ -78,7 +87,9 @@ const TabPanel = ({dataTestId, children}) => {
 };
 
 Tabs.propTypes = {
-  dataTestId: PropTypes.string
+  dataTestId: PropTypes.string,
+  tabOverride: PropTypes.string,
+  onHeaderClick: PropTypes.func
 };
 
 Tabs.TabHeaders = TabHeaders;

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -23,15 +23,6 @@ import SearchBar from "../../components/search-bar/search-bar";
 import {generateUrlWithQuery, generateObjectFromSearch} from "../../utils";
 
 const Dashboard = (props) => {
-  {/*
-    TODO: We got a major bug on our hands.
-    SearchBar appeared to be working fine till I used it in 2 places on the same page.
-    even though all my experienced told me it would be fine, it appears that the state between
-    the two SearchBar instances is persisting...if you enter 'wads' on one bar, then click another tab
-    the second bar will render with 'wads' as well. This is a huge problem and I think its because I wanted
-    the searchbar to manage its own state for input value. We need to control it on the container level and see
-    if the bug is still an issue.
-  */}
   const query = generateObjectFromSearch(props.location.search);
   const {
     getDashboardProjects,
@@ -97,7 +88,7 @@ const Dashboard = (props) => {
 
   const _refreshStories = async() => {
     const {page, itemsPerPage} = storiesData;
-    const storiesResponse = await getDashboardStories(page, itemsPerPage);
+    const storiesResponse = await getDashboardStories(page, itemsPerPage, storySearchData.searchedValue);
     if(!storiesResponse.error)
       setStoriesData(storiesResponse);
   };

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -228,6 +228,13 @@ const Dashboard = (props) => {
     }
   };
 
+  const _onHeaderClick = (headerIndex) => {
+    if(headerIndex === 0)
+      return _updateQueryString("activeTab", null);
+    
+    _updateQueryString("activeTab", headerIndex);
+  };
+
   return (
     <DashboardWrapper>
       {!projects || !stories ? (
@@ -236,7 +243,7 @@ const Dashboard = (props) => {
         <Fragment>
           <PageHeader text="Dashboard" textCenter dataTestId="dashboardHeader" />
           <ActionsMenu {...actionsMenuProps} />
-          <Tabs dataTestId="dashboardTabs">
+          <Tabs dataTestId="dashboardTabs" tabOverride={query.activeTab} onHeaderClick={_onHeaderClick}>
             <Tabs.TabHeaders>
               <Tabs.Header>My Projects</Tabs.Header>
               <Tabs.Header>My Stories</Tabs.Header>

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -136,7 +136,7 @@ const Dashboard = (props) => {
       getPage: async(page) => {
         if(page === storiesData.page)
           return;
-        const response = await getDashboardStories(page, storiesData.itemsPerPage);
+        const response = await getDashboardStories(page, storiesData.itemsPerPage, storySearchData.searchedValue);
         if(!response.error)
           setStoriesData(response);
         

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -23,6 +23,16 @@ import SearchBar from "../../components/search-bar/search-bar";
 import {generateUrlWithQuery, generateObjectFromSearch} from "../../utils";
 
 const Dashboard = (props) => {
+  {/*
+    TODO: We got a major bug on our hands.
+    SearchBar appeared to be working fine till I used it in 2 places on the same page.
+    even though all my experienced told me it would be fine, it appears that the state between
+    the two SearchBar instances is persisting...if you enter 'wads' on one bar, then click another tab
+    the second bar will render with 'wads' as well. This is a huge problem and I think its because I wanted
+    the searchbar to manage its own state for input value. We need to control it on the container level and see
+    if the bug is still an issue.
+  */}
+  const query = generateObjectFromSearch(props.location.search);
   const {
     getDashboardProjects,
     getDashboardStories,
@@ -45,15 +55,19 @@ const Dashboard = (props) => {
   const [newStoryData, setNewStoryData] = useState({});
   const [projectsData, setProjectsData] = useState(undefined);
   const [storiesData, setStoriesData] = useState(undefined);
-  const [searchValue, setSearchValue] = useState("");
+  const [projectSearchData, setProjectSearchData] = useState({
+    inputValue: query.projectSearch || "",
+    searchedValue: query.projectSearch || ""
+  });
+  const [storySearchData, setStorySearchData] = useState({
+    inputValue: query.storySearch || "",
+    searchedValue: query.storySearch || ""
+  });
 
   // called once, after the component is mounted.
   const _loadData = async() => {
-    const query = generateObjectFromSearch(props.location.search);
     const projectsResponse = await getDashboardProjects(query.projectsPage, undefined, query.projectSearch);
-    const storiesResponse = await getDashboardStories(query.storiesPage);
-    if(query.projectSearch)
-      setSearchValue(query.projectSearch);
+    const storiesResponse = await getDashboardStories(query.storiesPage, undefined, query.storySearch);
     
     if(!projectsResponse.error)
       setProjectsData(projectsResponse);
@@ -74,7 +88,7 @@ const Dashboard = (props) => {
 
   const _refreshProjects = async() => {
     const {page, itemsPerPage} = projectsData;
-    const projectsResponse = await getDashboardProjects(page, itemsPerPage, searchValue);
+    const projectsResponse = await getDashboardProjects(page, itemsPerPage, projectSearchData.searchedValue);
     if(!projectsResponse.error)
       setProjectsData(projectsResponse);
     
@@ -110,7 +124,7 @@ const Dashboard = (props) => {
       getPage: async(page) => {
         if(page === projectsData.page)
           return;
-        const response = await getDashboardProjects(page, projectsData.itemsPerPage, searchValue);
+        const response = await getDashboardProjects(page, projectsData.itemsPerPage, projectSearchData.searchedValue);
         if(!response.error)
           setProjectsData(response);
         
@@ -149,15 +163,23 @@ const Dashboard = (props) => {
     }]
   };
 
-  const searchBarProps = {
+  const projectsSearchBarProps = {
     id: "dashboardProjectSearch",
     dataTestId: `dashboardProjectSearch`,
     label: "Project Name",
     placeholder: "Search by project name",
-    searchedValue: searchValue,
+    value: projectSearchData.inputValue,
+    searchedValue: projectSearchData.searchedValue,
+    onChange: (value) => setProjectSearchData({
+      ...projectSearchData,
+      inputValue: value
+    }),
     search: async(value) => {
       _updateQueryString("projectSearch", value ? value : null);
-      setSearchValue(value);
+      setProjectSearchData({
+        ...projectSearchData,
+        searchedValue: value
+      });
       const {itemsPerPage} = projectsData;
       const projectsResponse = await getDashboardProjects(1, itemsPerPage, value);
       _updateQueryString("projectsPage", 1);
@@ -166,12 +188,52 @@ const Dashboard = (props) => {
     },
     clear: async() => {
       _updateQueryString("projectSearch", null);
-      setSearchValue("");
+      setProjectSearchData({
+        inputValue: "",
+        searchedValue: ""
+      });
       const {itemsPerPage} = projectsData;
       const projectsResponse = await getDashboardProjects(1, itemsPerPage);
       _updateQueryString("projectsPage", 1);
       if(!projectsResponse.error)
         setProjectsData(projectsResponse);
+    }
+  };
+
+  const storiesSearchBarProps = {
+    id: "dashboardStorySearch",
+    dataTestId: `dashboardStorySearch`,
+    label: "Story Name",
+    placeholder: "Search by story name",
+    value: storySearchData.inputValue,
+    searchedValue: storySearchData.searchedValue,
+    onChange: (value) => setStorySearchData({
+      ...storySearchData,
+      inputValue: value
+    }),
+    search: async(value) => {
+      _updateQueryString("storySearch", value ? value : null);
+      setStorySearchData({
+        ...storySearchData,
+        searchedValue: value
+      });
+      const {itemsPerPage} = storiesData;
+      const storiesResponse = await getDashboardStories(1, itemsPerPage, value);
+      _updateQueryString("storiesPage", 1);
+      if(!storiesResponse.error)
+        setStoriesData(storiesResponse);
+    },
+    clear: async() => {
+      _updateQueryString("storySearch", null);
+      setStorySearchData({
+        inputValue: "",
+        searchedValue: ""
+      });
+      const {itemsPerPage} = storiesData;
+      const storiesResponse = await getDashboardStories(1, itemsPerPage);
+      _updateQueryString("storiesPage", 1);
+      if(!storiesResponse.error)
+        setStoriesData(storiesResponse);
     }
   };
 
@@ -190,15 +252,12 @@ const Dashboard = (props) => {
             </Tabs.TabHeaders>
             <Tabs.TabPanels>
               <Tabs.Panel>
-                <SearchBar {...searchBarProps}/>
+                <SearchBar {...projectsSearchBarProps}/>
                 <ProjectsTable {...projectsTableProps} />
               </Tabs.Panel>
               <Tabs.Panel>
-                {stories.length ? (
-                  <StoriesTable {...storiesTableProps} />
-                ) : (
-                  <div>You are not the owner/creator of any stories</div>
-                )}
+                <SearchBar {...storiesSearchBarProps}/>
+                <StoriesTable {...storiesTableProps} />
               </Tabs.Panel>
             </Tabs.TabPanels>
           </Tabs>

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -221,7 +221,7 @@ describe("<Dashboard />", () => {
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
     const storiesTab = getByText("My Stories");
     fireEvent.click(storiesTab);
-    expect(getByText("You are not the owner/creator of any stories")).toBeDefined();
+    expect(getByText("There are no stories to display")).toBeDefined();
   });
 
   it("should render the StoriesTable when the Stories tab is clicked", async() => {
@@ -255,5 +255,18 @@ describe("<Dashboard />", () => {
     expect(getByTestId("dashboardProjectSearch")).toBeDefined();
     expect(getByTestId("dashboardProjectSearch.input")).toBeDefined();
     expect(getByTestId("dashboardProjectSearch.search")).toBeDefined();
+  });
+
+  it("should render the stories search bar", async() => {
+    const {queryByTestId, getByText} = render(<Dashboard {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const storiesTab = getByText("My Stories");
+    expect(queryByTestId("dashboardStorySearch")).toBeNull();
+    expect(queryByTestId("dashboardStorySearch.input")).toBeNull();
+    expect(queryByTestId("dashboardStorySearch.search")).toBeNull();
+    fireEvent.click(storiesTab);
+    expect(queryByTestId("dashboardStorySearch")).toBeDefined();
+    expect(queryByTestId("dashboardStorySearch.input")).toBeDefined();
+    expect(queryByTestId("dashboardStorySearch.search")).toBeDefined();
   });
 });

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -67,6 +67,10 @@ const ProjectDetails = (props) => {
   const [deleteStoryData, setDeleteStoryData] = useState({});
   const [showStoryModal, setShowStoryModal] = useState(false);
   const [memberSearchValue, setMemberSearchValue] = useState(query.memberSearch || "");
+  const [memberSearchData, setMemberSearchData] = useState({
+    inputValue: query.memberSearch || "",
+    searchedValue: query.memberSearch || ""
+  });
 
   // This is called once, on component mount (inside useEffect)
   const _loadData = async() => {
@@ -202,10 +206,18 @@ const ProjectDetails = (props) => {
     dataTestId: `projectMembersSearch`,
     label: "Member Name",
     placeholder: "Search by member name",
-    searchedValue: memberSearchValue,
+    searchedValue: memberSearchData.searchedValue,
+    value: memberSearchData.inputValue,
+    onChange: (value) => setMemberSearchData({
+      ...memberSearchData,
+      inputValue: value
+    }),
     search: async(value) => {
       _updateQueryString("memberSearch", value ? value : null);
-      setMemberSearchValue(value);
+      setMemberSearchData({
+        ...memberSearchData,
+        searchedValue: value
+      });
       const {itemsPerPage} = membershipsData;
       const membershipsResponse = await getMemberships(projectId, 1, itemsPerPage, value);
       _updateQueryString("membersPage", 1);
@@ -214,7 +226,10 @@ const ProjectDetails = (props) => {
     },
     clear: async() => {
       _updateQueryString("memberSearch", null);
-      setMemberSearchValue("");
+      setMemberSearchData({
+        inputValue: "",
+        searchedValue: ""
+      });
       const {itemsPerPage} = membershipsData;
       const membershipsResponse = await getMemberships(projectId, 1, itemsPerPage);
       _updateQueryString("membersPage", 1);

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -278,6 +278,13 @@ const ProjectDetails = (props) => {
     }
   };
 
+  const _onHeaderClick = (headerIndex) => {
+    if(headerIndex === 0)
+      return _updateQueryString("activeTab", null);
+    
+    _updateQueryString("activeTab", headerIndex);
+  };
+
   return (
     <ProjectDetailsWrapper>
       {pageError ? (
@@ -292,7 +299,7 @@ const ProjectDetails = (props) => {
             {userRoles && (userRoles.isAdmin || userRoles.isManager || userRoles.isDeveloper) && (
               <ActionsMenu {...actionsMenuProps} />
             )}
-            <Tabs dataTestId="projectDetailsTabs">
+            <Tabs dataTestId="projectDetailsTabs" tabOverride={query.activeTab} onHeaderClick={_onHeaderClick}>
               <Tabs.TabHeaders>
                 <Tabs.Header>Details</Tabs.Header>
                 <Tabs.Header>Members</Tabs.Header>

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -66,17 +66,20 @@ const ProjectDetails = (props) => {
   const [showAddMemberModal, setShowAddMemberModal] = useState(false);
   const [deleteStoryData, setDeleteStoryData] = useState({});
   const [showStoryModal, setShowStoryModal] = useState(false);
-  const [memberSearchValue, setMemberSearchValue] = useState(query.memberSearch || "");
   const [memberSearchData, setMemberSearchData] = useState({
     inputValue: query.memberSearch || "",
     searchedValue: query.memberSearch || ""
+  });
+  const [storySearchData, setStorySearchData] = useState({
+    inputValue: query.storySearch || "",
+    searchedValue: query.storySearch || ""
   });
 
   // This is called once, on component mount (inside useEffect)
   const _loadData = async() => {
     const projectResponse = await getProject(projectId, true);
     const membershipResponse = await getMemberships(projectId, query.membersPage, null, query.memberSearch);
-    const storiesResponse = await getStories(projectId, query.storiesPage);
+    const storiesResponse = await getStories(projectId, query.storiesPage, null, query.storySearch);
 
     if(projectResponse && projectResponse.error)
       return setPageError(projectResponse.error);
@@ -101,7 +104,7 @@ const ProjectDetails = (props) => {
   // This is called when we delete or edit a membership.
   const _reloadMemberships = async() => {
     const {itemsPerPage, page} = membershipsData;
-    const response = await getMemberships(projectId, page, itemsPerPage);
+    const response = await getMemberships(projectId, page, itemsPerPage, memberSearchData.searchedValue);
     if(response && response.error)
       return setPageError(response.error);
     
@@ -111,7 +114,7 @@ const ProjectDetails = (props) => {
     // This is called when we delete or edit a story.
     const _reloadStories = async() => {
       const {itemsPerPage, page} = storiesData;
-      const response = await getStories(projectId, page, itemsPerPage);
+      const response = await getStories(projectId, page, itemsPerPage, storySearchData.searchedValue);
       if(response && response.error)
         return setPageError(response.error);
       
@@ -147,7 +150,7 @@ const ProjectDetails = (props) => {
       if(page === membershipsData.page)
         return;
       _updateQueryString("membersPage", page);
-      const response = await getMemberships(projectId, page, membershipsData.itemsPerPage);
+      const response = await getMemberships(projectId, page, membershipsData.itemsPerPage, memberSearchData.searchedValue);
       if(response.error)
         return setPageError(response.error);
       
@@ -163,7 +166,7 @@ const ProjectDetails = (props) => {
       if(page === storiesData.page)
         return;
       _updateQueryString("storiesPage", page);
-      const response = await getStories(projectId, page, storiesData.itemsPerPage);
+      const response = await getStories(projectId, page, storiesData.itemsPerPage, storySearchData.searchedValue);
       if(response.error)
         return setPageError(response.error);
       
@@ -238,6 +241,43 @@ const ProjectDetails = (props) => {
     }
   };
 
+  const storiesSearchBarProps = {
+    id: "projectStoriesSearch",
+    dataTestId: `projectStoriesSearch`,
+    label: "Story Name",
+    placeholder: "Search by story name",
+    searchedValue: storySearchData.searchedValue,
+    value: storySearchData.inputValue,
+    onChange: (value) => setStorySearchData({
+      ...storySearchData,
+      inputValue: value
+    }),
+    search: async(value) => {
+      _updateQueryString("storySearch", value ? value : null);
+      setStorySearchData({
+        ...storySearchData,
+        searchedValue: value
+      });
+      const {itemsPerPage} = storiesData;
+      const storiesResponse = await getStories(projectId, 1, itemsPerPage, value);
+      _updateQueryString("storiesPage", 1);
+      if(!storiesResponse.error)
+        setStoriesData(storiesResponse);
+    },
+    clear: async() => {
+      _updateQueryString("storySearch", null);
+      setStorySearchData({
+        inputValue: "",
+        searchedValue: ""
+      });
+      const {itemsPerPage} = storiesData;
+      const storiesResponse = await getStories(projectId, 1, itemsPerPage);
+      _updateQueryString("storiesPage", 1);
+      if(!storiesResponse.error)
+        setStoriesData(storiesResponse);
+    }
+  };
+
   return (
     <ProjectDetailsWrapper>
       {pageError ? (
@@ -309,23 +349,22 @@ const ProjectDetails = (props) => {
                   />
                 </Tabs.Panel>
                 <Tabs.Panel>
-                  {storiesData.stories.length ? (
-                    <StoriesTable
-                      stories={storiesData.stories}
-                      project={{
-                        id: project.id,
-                        name: project.name,
-                        userRoles: userRoles
-                      }}
-                      actions={{
-                        deleteStory: (story) => setDeleteStoryData(story),
-                        viewStory: (story) => historyPush(`/projects/${project.id}/stories/${story.id}`)
-                      }}
-                      pagination={storiesPagination}
-                    />
-                  ) : (
-                    <div>This project has no stories</div>
+                  {userRoles && (userRoles.isAdmin || userRoles.isManager || userRoles.isDeveloper || userRoles.isViewer) && (
+                    <SearchBar {...storiesSearchBarProps} />
                   )}
+                  <StoriesTable
+                    stories={storiesData.stories}
+                    project={{
+                      id: project.id,
+                      name: project.name,
+                      userRoles: userRoles
+                    }}
+                    actions={{
+                      deleteStory: (story) => setDeleteStoryData(story),
+                      viewStory: (story) => historyPush(`/projects/${project.id}/stories/${story.id}`)
+                    }}
+                    pagination={storiesPagination}
+                  />
                 </Tabs.Panel>
               </Tabs.TabPanels>
             </Tabs>

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -455,12 +455,34 @@ describe("<ProjectDetails />", () => {
     expect(queryByTestId("projectMembersSearch")).toBeNull();
   });
 
-  it("should render the members searchbar for members", async() => {
+  it("should render the members searchbar for project members", async() => {
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     expect(queryByTestId("projectMembersSearch")).toBeNull();
     fireEvent.click(membersTab);
     expect(queryByTestId("projectMembersSearch")).toBeDefined();
+  });
+
+  it("should not render the backlog searchbar for non-members", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce({...mockProjectResponse, userRoles: {}});
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    store.dispatch.mockReturnValueOnce(mockStoriesResponse);
+    const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
+    const backlogTab = getByText("Backlog");
+    expect(queryByTestId("projectStoriesSearch")).toBeNull();
+    fireEvent.click(backlogTab);
+    expect(queryByTestId("projectStoriesSearch")).toBeNull();
+  });
+
+  it("should render the backlog searchbar for project members", async() => {
+    const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
+    const backlogTab = getByText("Backlog");
+    expect(queryByTestId("projectStoriesSearch")).toBeNull();
+    fireEvent.click(backlogTab);
+    expect(queryByTestId("projectStoriesSearch")).toBeDefined();
   });
 });

--- a/src/store/actions/dashboard.js
+++ b/src/store/actions/dashboard.js
@@ -20,12 +20,14 @@ export const getDashboardProjects = (page, itemsPerPage, searchValue) => dispatc
   });
 };
 
-export const getDashboardStories = (page, itemsPerPage) => dispatch => {
+export const getDashboardStories = (page, itemsPerPage, filterName) => dispatch => {
   const queryString = {};
   if(page)
     queryString.page = page;
   if(itemsPerPage)
     queryString.itemsPerPage = itemsPerPage;
+  if(filterName)
+    queryString.filterName = filterName;
   return dispatch({
     types: [DASHBOARD_REQUEST_START, DASHBOARD_REQUEST_SUCCESS, DASHBOARD_REQUEST_FAILURE],
     request: request.get(`${apiRoute}/stories`).query(queryString)

--- a/src/store/actions/story.js
+++ b/src/store/actions/story.js
@@ -43,12 +43,14 @@ export const deleteStory = (storyData, confirm) => dispatch => {
   });
 };
 
-export const getStories = (projectId, page, itemsPerPage) => dispatch => {
+export const getStories = (projectId, page, itemsPerPage, filterName) => dispatch => {
   const queryString = {};
   if(page)
     queryString.page = page;
   if(itemsPerPage)
     queryString.itemsPerPage = itemsPerPage;
+  if(filterName)
+    queryString.filterName = filterName;
   return dispatch({
     types: [STORY_REQUEST_START, STORY_REQUEST_SUCCESS, STORY_REQUEST_FAILURE],
     request: request.get(`/api/projects/${projectId}/stories`).query(queryString)


### PR DESCRIPTION
This PR contains:
- Update to `SearchBar` making it a fully controller component. Was experiencing weird bugs without this update. Updated unit tests.
- Update `StoriesTable` to display a message when there are no stories to display. Added unit test.
- Added `SearchBar` to `Dashboard` for filtering stories by name. Added unit test.
- Added `SearchBar` to `ProjectDetails` for filtering backlog stories by name. Added unit test.
- Added `filterName` param/query-string to `getStories` redux action.
- Added `filterName` param/query-string to `getDashboardStories` redux action.
- Update to `Tabs` component:
  * Added `tabOverride` prop that can be used to render a specific tab when the component is mounted.
  * Added `onHeaderClick` prop that is called, if present, when a tab header is clicked.
- Added `activeTab` query-string tracking to `Dashboard` and `ProjectDetails` allowing a specific view to be bookmarked.