### PR TITLE
Modal Updates

### DIFF
--- a/src/components/markdown-text/markdown-text.styles.js
+++ b/src/components/markdown-text/markdown-text.styles.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
-
+import {
+  black1a
+} from "../../common-styles/variables";
 export const MarkdownTextWrapper = styled.div`
   position: relative;
 
@@ -8,7 +10,8 @@ export const MarkdownTextWrapper = styled.div`
     margin: 0;
     font-size: 85%;
     background-color: rgba(27,31,35,.05);
-    border-radius: 6px;
+    background-color: ${black1a};
+    border-radius: 5px;
   }
 
   & pre {
@@ -17,8 +20,8 @@ export const MarkdownTextWrapper = styled.div`
     overflow: auto;
     font-size: 85%;
     line-height: 1.45;
-    background-color: #f6f8fa;
-    border-radius: 6px;
+    background-color: ${black1a};
+    border-radius: 5px;
 
     & code {
       display: inline;

--- a/src/components/markdown-text/markdown-text.styles.js
+++ b/src/components/markdown-text/markdown-text.styles.js
@@ -2,4 +2,33 @@ import styled from "styled-components";
 
 export const MarkdownTextWrapper = styled.div`
   position: relative;
+
+  & code {
+    padding: .2em .4em;
+    margin: 0;
+    font-size: 85%;
+    background-color: rgba(27,31,35,.05);
+    border-radius: 6px;
+  }
+
+  & pre {
+    word-wrap: normal;
+    padding: 16px;
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
+    background-color: #f6f8fa;
+    border-radius: 6px;
+
+    & code {
+      display: inline;
+      padding: 0;
+      margin: 0;
+      overflow: visible;
+      line-height: inherit;
+      word-wrap: normal;
+      background-color: initial;
+      border: 0;
+    }
+  }
 `;

--- a/src/components/membership-modal/membership-modal.jsx
+++ b/src/components/membership-modal/membership-modal.jsx
@@ -15,7 +15,7 @@ import {
 const MembershipModal = (props) => {
   const membership = props.membership;
   const isEdit = !!membership;
-  const [state, setState] = useState({
+  const initialState = {
     username: isEdit ? membership.user.displayName : "",
     usernameError: "",
     roles: isEdit ? {
@@ -28,16 +28,16 @@ const MembershipModal = (props) => {
       isManager: false,
       isDeveloper: false,
       isViewer: true
-    },
-    availableUsers: isEdit ? [] : undefined
-  });
+    }
+  };
+  const [state, setState] = useState(initialState);
+  const [availableUsers, setAvailableUsers] = useState(isEdit ? [] : undefined);
+
+  const hasChanges = () => JSON.stringify(initialState) !== JSON.stringify(state);
 
   const _loadData = async() => {
     const response = await props.getAvailableUsers(props.project);
-    setState({
-      ...state,
-      availableUsers: response.users
-    });
+    setAvailableUsers(response.users);
   };
 
   useEffect(() => {
@@ -50,7 +50,7 @@ const MembershipModal = (props) => {
   const _submitTooltip = () => _submitDisabled() ? props.requestInProgress ? "request in progress" : "missing required fields" : "";
 
   const _onSubmit = async() => {
-    const {username, roles, availableUsers} = state;
+    const {username, roles} = state;
     
     // Validate username input matches something available, only validate for new memberships.
     if(!isEdit && availableUsers.indexOf(username) === -1)
@@ -83,7 +83,8 @@ const MembershipModal = (props) => {
       text: isEdit ? "Edit Roles" : "New Membership"
     },
     dataTestId: "membershipModal",
-    small: true
+    small: true,
+    confirmBeforeClose: hasChanges()
   };
 
   const inputProps = {
@@ -127,7 +128,7 @@ const MembershipModal = (props) => {
       focusedPlaceholder: "Start typing to filter options",
       value: state.username,
       onChange: (value) => setState({...state, username: value, usernameError: ""}),
-      items: state.availableUsers,
+      items: availableUsers,
       isRequired: true,
       errorText: state.usernameError,
       disabled: isEdit
@@ -137,7 +138,7 @@ const MembershipModal = (props) => {
   return (
     <MembershipModalWrapper>
       <Modal {...modalProps}>
-        {!state.availableUsers ? (
+        {!availableUsers ? (
           <LoadingSpinner alignCenter dataTestId="membershipModalLoader" message="Loading available users" />
         ) : (
           <Fragment>

--- a/src/components/membership-modal/membership-modal.spec.jsx
+++ b/src/components/membership-modal/membership-modal.spec.jsx
@@ -321,4 +321,64 @@ describe("<MembershipModal />", () => {
     fireEvent.click(submitButton);
     await waitFor(() => expect(props.onClose).toHaveBeenCalled());
   });
+
+
+
+
+
+
+
+
+  it("should prevent the modal from autoclosing on click if there are any state changes", async() => {
+    const {getByTestId} = render(<MembershipModal {...props} />);
+    await waitFor(() => expect(props.getAvailableUsers).toHaveBeenCalledWith(props.project));
+    const modalBackground = getByTestId("membershipModal.wrapper");
+    const nameInput = getByTestId("membershipUsernameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(modalBackground);
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("should show a confirm prompt if cancel is clicked and there are state changes", async() => {
+    window.confirm = jest.fn();
+    const {getByTestId} = render(<MembershipModal {...props}/>);
+    await waitFor(() => expect(props.getAvailableUsers).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("membershipModal.actions.secondaryButton");
+    const nameInput = getByTestId("membershipUsernameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+  });
+
+  it("should call onClose if confirm prompt returns true", async() => {
+    window.confirm = jest.fn().mockReturnValueOnce(true);
+    const {getByTestId} = render(<MembershipModal {...props}/>);
+    await waitFor(() => expect(props.getAvailableUsers).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("membershipModal.actions.secondaryButton");
+    const nameInput = getByTestId("membershipUsernameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("should not call onClose if confirm prompt returns false", async() => {
+    window.confirm = jest.fn().mockReturnValueOnce(false);
+    const {getByTestId} = render(<MembershipModal {...props}/>);
+    await waitFor(() => expect(props.getAvailableUsers).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("membershipModal.actions.secondaryButton");
+    const nameInput = getByTestId("membershipUsernameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/membership-modal/membership-modal.spec.jsx
+++ b/src/components/membership-modal/membership-modal.spec.jsx
@@ -322,13 +322,6 @@ describe("<MembershipModal />", () => {
     await waitFor(() => expect(props.onClose).toHaveBeenCalled());
   });
 
-
-
-
-
-
-
-
   it("should prevent the modal from autoclosing on click if there are any state changes", async() => {
     const {getByTestId} = render(<MembershipModal {...props} />);
     await waitFor(() => expect(props.getAvailableUsers).toHaveBeenCalledWith(props.project));

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -11,7 +11,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import Button from "../button/button";
-// TODO: Write new tests to validate props.confirmBeforeClose is working as expected.
+
 const Modal = (props) => {
   const {dataTestId} = props;
   const _handleClick = useCallback((event) => {

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -11,15 +11,16 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import Button from "../button/button";
-
+// TODO: Write new tests to validate props.confirmBeforeClose is working as expected.
 const Modal = (props) => {
   const {dataTestId} = props;
   const _handleClick = useCallback((event) => {
-    // modalWrapper is the background behind the modal box, close the modal if this is clicked.
+    // modalWrapper is the background behind the modal box, close the modal if this is clicked. unless
+    // props.confirmBeforeClose is true.
     const modalWrapper = document.getElementById("compass-modal");
-    if(event.target == modalWrapper)
+    if(!props.confirmBeforeClose && event.target == modalWrapper)
       props.onClose();
-  }, [props.onClose]);
+  }, [props.onClose, props.confirmBeforeClose]);
 
   // Attach the clickHandler, if the modal is open, so we can close the modal if the background is clicked.
   useEffect(() => {
@@ -27,10 +28,20 @@ const Modal = (props) => {
     return () => window.removeEventListener("mousedown", _handleClick); // Remove listener if the modal is unmounted.
   });
 
+  const _onClose = () => {
+    if(props.confirmBeforeClose) {
+      const confirmResult = confirm("There are unsaved changes. Are you sure you want to close?");
+      if(confirmResult)
+        return props.onClose();
+    }
+    else
+      props.onClose();
+  };
+
   return (
     <ModalWrapper data-testid={`${dataTestId}.wrapper`} id="compass-modal">
       <ModalBox small={props.small}>
-        <CloseButton data-testid={`${dataTestId}.closeButton`} onClick={props.onClose}>
+        <CloseButton data-testid={`${dataTestId}.closeButton`} onClick={_onClose}>
           <FontAwesomeIcon icon={faTimes} fixedWidth />
         </CloseButton>
         {props.header && (
@@ -59,7 +70,7 @@ const Modal = (props) => {
           <Button
             secondary
             small
-            onClick={props.onClose}
+            onClick={_onClose}
             label="Cancel"
             dataTestId={`${dataTestId}.actions.secondaryButton`}
           />
@@ -82,7 +93,8 @@ Modal.propTypes = {
   }),
   centerHeader: PropTypes.bool,
   dataTestId: PropTypes.string,
-  danger: PropTypes.bool
+  danger: PropTypes.bool,
+  confirmBeforeClose: PropTypes.bool
 };
 
 export default Modal;

--- a/src/components/modal/modal.spec.jsx
+++ b/src/components/modal/modal.spec.jsx
@@ -33,11 +33,28 @@ describe("<Modal />", () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("should not call the onClose method when the area outside of the modal box is clicked and confirmBeforeClose is true", () => {
+    props.confirmBeforeClose = true;
+    const {getByTestId} = render(<Modal {...props} />);
+    const outsideArea = getByTestId(`${props.dataTestId}.wrapper`);
+    fireEvent.mouseDown(outsideArea);
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
   it("should call the onClose method when the close button is clicked", () => {
     const {getByTestId} = render(<Modal {...props} />);
     const closeButton = getByTestId(`${props.dataTestId}.closeButton`);
     fireEvent.click(closeButton);
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show a confirm prompt if close button is clicked and confirmBeforeClose is true", () => {
+    props.confirmBeforeClose = true;
+    window.confirm = jest.fn();
+    const {getByTestId} = render(<Modal {...props} />);
+    const closeButton = getByTestId(`${props.dataTestId}.closeButton`);
+    fireEvent.click(closeButton);
+    expect(window.confirm).toHaveBeenCalled();
   });
 
   it("should render the header text and icons if provided", () => {
@@ -83,6 +100,15 @@ describe("<Modal />", () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("should show a confirm prompt if cancel button is clicked and confirmBeforeClose is true", () => {
+    props.confirmBeforeClose = true;
+    window.confirm = jest.fn();
+    const {getByTestId} = render(<Modal {...props} />);
+    const cancelButton = getByTestId(`${props.dataTestId}.actions.secondaryButton`);
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+  });
+
   it("should render the submit tooltip if present", () => {
     const {getByText} = render(<Modal {...props}/>);
     expect(getByText(props.submitTooltip)).toBeDefined();
@@ -92,5 +118,27 @@ describe("<Modal />", () => {
     props.danger = true;
     const {getByText} = render(<Modal {...props} />);
     expect(getByText("Delete")).toBeDefined();
+  });
+
+  it("should call onClose if a confirm prompt returns true", () => {
+    props.confirmBeforeClose = true;
+    window.confirm = jest.fn();
+    window.confirm.mockReturnValue(true);
+    const {getByTestId} = render(<Modal {...props} />);
+    const cancelButton = getByTestId(`${props.dataTestId}.actions.secondaryButton`);
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("should not call onClose if a confirm prompt returns false", () => {
+    props.confirmBeforeClose = true;
+    window.confirm = jest.fn();
+    window.confirm.mockReturnValue(false);
+    const {getByTestId} = render(<Modal {...props} />);
+    const cancelButton = getByTestId(`${props.dataTestId}.actions.secondaryButton`);
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/project-modal/project-modal.jsx
+++ b/src/components/project-modal/project-modal.jsx
@@ -8,14 +8,18 @@ import TextArea from "../text-area/text-area";
 
 const ProjectModal = (props) => {
   const isEdit = !!props.project;
-  const [state, setState] = useState({
+  const initialState = {
     name: isEdit ? props.project.name : "",
     description: isEdit ? props.project.description : "",
     isPrivate: isEdit ? props.project.isPrivate : false,
     nameError: undefined,
     descriptionError: undefined
-  });
-  
+  };
+  const [state, setState] = useState(initialState);
+
+  // Tracking if any data on the form has changed.
+  const hasChanges = () => JSON.stringify(initialState) !== JSON.stringify(state);
+
   const _submitDisabled = () => (
     !state.name ||
     !!state.nameError ||
@@ -27,7 +31,6 @@ const ProjectModal = (props) => {
 
   const _onSubmit = async() => {
     const { name, description, isPrivate } = state;
-    // const response = await props.onSubmit(name, description, isPrivate);
     let response;
     if(isEdit)
       response = await props.onSubmit(props.project.id, name, description, isPrivate);
@@ -57,7 +60,8 @@ const ProjectModal = (props) => {
       startIcon: faFolderPlus,
       text: isEdit ? "Edit Project" : "New Project"
     },
-    dataTestId: "projectModal"
+    dataTestId: "projectModal",
+    confirmBeforeClose: hasChanges()
   };
 
   const inputProps = {

--- a/src/components/project-modal/project-modal.spec.jsx
+++ b/src/components/project-modal/project-modal.spec.jsx
@@ -152,4 +152,53 @@ describe("<ProjectModal />", () => {
     await waitFor(() => expect(props.onSubmit).toHaveBeenCalled());
     expect(props.onSubmit).toHaveBeenCalledWith("testId", "test project", "this is a test.", true);
   });
+
+  it("should prevent the modal from autoclosing on click if there are any state changes", () => {
+    const {getByTestId} = render(<ProjectModal {...props} />);
+    const modalBackground = getByTestId("projectModal.wrapper");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(modalBackground);
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("should show a confirm prompt if cancel is clicked and there are state changes", () => {
+    window.confirm = jest.fn();
+    const {getByTestId} = render(<ProjectModal {...props}/>);
+    const cancelButton = getByTestId("projectModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+  });
+
+  it("should call onClose if confirm prompt returns true", () => {
+    window.confirm = jest.fn().mockReturnValueOnce(true);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
+    const cancelButton = getByTestId("projectModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("should not call onClose if confirm prompt returns false", () => {
+    window.confirm = jest.fn().mockReturnValueOnce(false);
+    const {getByTestId} = render(<ProjectModal {...props}/>);
+    const cancelButton = getByTestId("projectModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/story-modal/story-modal.jsx
+++ b/src/components/story-modal/story-modal.jsx
@@ -11,22 +11,23 @@ import TextArea from "../text-area/text-area";
 const StoryModal = (props) => {
   const story = props.story;
   const isEdit = !!story;
-  const [state, setState] = useState({
+  const initialState = {
     name: isEdit ? story.name : "",
     details: isEdit && story.details ? story.details : "",
     owner: isEdit && story.owner ? story.owner.displayName : "",
     nameError: undefined,
     detailsError: undefined,
-    ownerError: undefined,
-    memberNames: undefined
-  });
+    ownerError: undefined
+  };
+  const [state, setState] = useState(initialState);
+  const [memberNames, setMemberNames] = useState(undefined);
+
+  // Tracking if any data on the form has changed.
+  const hasChanges = () => JSON.stringify(initialState) !== JSON.stringify(state);
 
   const _loadData = async() => {
     const response = await props.getMemberNames(props.project);
-    setState({
-      ...state,
-      memberNames: response.users
-    });
+    setMemberNames(response.users);
   };
 
   useEffect(() => {
@@ -54,7 +55,7 @@ const StoryModal = (props) => {
   };
 
   const _onSubmit = async() => {
-    const {name, details, owner, memberNames} = state;
+    const {name, details, owner} = state;
     
     // Validate owner input matches something valid.
     if(owner && memberNames.indexOf(owner) === -1)
@@ -90,7 +91,8 @@ const StoryModal = (props) => {
       startIcon: isEdit ? faEdit : faBook,
       text: isEdit ? "Edit Story" : "New Story"
     },
-    dataTestId: "storyModal"
+    dataTestId: "storyModal",
+    confirmBeforeClose: hasChanges()
   };
 
   const inputProps = {
@@ -121,7 +123,7 @@ const StoryModal = (props) => {
       focusedPlaceholder: "Start typing to filter options",
       value: state.owner,
       onChange: (value) => setState({...state, owner: value, ownerError: ""}),
-      items: state.memberNames,
+      items: memberNames,
       errorText: state.ownerError
     }
   };
@@ -129,7 +131,7 @@ const StoryModal = (props) => {
   return (
     <StoryModalWrapper>
       <Modal {...modalProps}>
-        {!state.memberNames ? (
+        {!memberNames ? (
           <LoadingSpinner alignCenter dataTestId="storyModalLoader" message="Loading available members" />
         ) : (
           <Fragment>

--- a/src/components/story-modal/story-modal.spec.jsx
+++ b/src/components/story-modal/story-modal.spec.jsx
@@ -269,4 +269,58 @@ describe("<StoryModal />", () => {
     fireEvent.click(submitButton);
     await waitFor(() => expect(props.onSubmit).toHaveBeenCalledWith(props.project, props.story, nameVal, detailsVal, ownerVal));
   });
+
+
+  it("should prevent the modal from autoclosing on click if there are any state changes", async() => {
+    const {getByTestId} = render(<StoryModal {...props} />);
+    await waitFor(() => expect(props.getMemberNames).toHaveBeenCalledWith(props.project));
+    const modalBackground = getByTestId("storyModal.wrapper");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(modalBackground);
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("should show a confirm prompt if cancel is clicked and there are state changes", async() => {
+    window.confirm = jest.fn();
+    const {getByTestId} = render(<StoryModal {...props}/>);
+    await waitFor(() => expect(props.getMemberNames).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("storyModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+  });
+
+  it("should call onClose if confirm prompt returns true", async() => {
+    window.confirm = jest.fn().mockReturnValueOnce(true);
+    const {getByTestId} = render(<StoryModal {...props}/>);
+    await waitFor(() => expect(props.getMemberNames).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("storyModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("should not call onClose if confirm prompt returns false", async() => {
+    window.confirm = jest.fn().mockReturnValueOnce(false);
+    const {getByTestId} = render(<StoryModal {...props}/>);
+    await waitFor(() => expect(props.getMemberNames).toHaveBeenCalledWith(props.project));
+    const cancelButton = getByTestId("storyModal.actions.secondaryButton");
+    const nameInput = getByTestId("nameInput.input");
+    fireEvent.change(nameInput, {
+      target: {value: "somevalue"}
+    });
+    fireEvent.click(cancelButton);
+    expect(window.confirm).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
 });

--- a/src/containers/dashboard/dashboard.styles.js
+++ b/src/containers/dashboard/dashboard.styles.js
@@ -6,11 +6,11 @@ import {SearchBarWrapper} from "../../components/search-bar/search-bar.styles";
 
 export const DashboardWrapper = styled.div`
   position: relative;
-  height: 100%;
   width: 100%;
 
   & ${TabsWrapper} {
-    padding-top: 30px;
+    margin-top: 30px;
+    margin-bottom: 30px;
     margin-left: 50px;
     margin-right: 50px;
   }

--- a/src/containers/project-details/project-details.styles.js
+++ b/src/containers/project-details/project-details.styles.js
@@ -19,10 +19,10 @@ export const ProjectDetailsWrapper = styled.div`
   width: 100%;
 
   & ${TabsWrapper} {
-    padding-top: 30px;
+    margin-top: 30px;
+    margin-bottom: 30px;
     margin-left: 50px;
     margin-right: 50px;
-    height: 100%;
   }
 
   & ${Spinner} {

--- a/src/containers/story-details/story-details.styles.js
+++ b/src/containers/story-details/story-details.styles.js
@@ -15,10 +15,10 @@ export const StoryDetailsWrapper = styled.div`
   width: 100%;
 
   & ${TabsWrapper} {
-    padding-top: 30px;
+    margin-top: 30px;
+    margin-bottom: 30px;
     margin-left: 50px;
     margin-right: 50px;
-    height: 100%;
   }
 
   & ${Spinner} {


### PR DESCRIPTION
When entering data on a modal, potentially you are filling out hundreds of characters. Modals up until this point have had a default feature that auto-closes the modal if the the wrapper background is clicked. This would be _very_ undesirable from a UX standpoint...to accidently click off the modal and lose all my work.

This PR contains:
- Style updates to `MarkdownText` and `Tab` components.
- Update to `Modal` component. added the `confirmBeforeClose` prop. Added unit tests.
- Update to `ProjectModal` to confirm before closing if there are any input changes. Added unit tests.
- Update to `StoryModal` to confirm before closing if there are any input changes. Added unit tests.
- Update to `MembershipModal` to confirm before closing if there are any input changes. Added unit tests.