### PR TITLE
Add ProjectConfigs Page

### DIFF
--- a/src/components/modal/modal.styles.js
+++ b/src/components/modal/modal.styles.js
@@ -25,6 +25,7 @@ export const ModalWrapper = styled.div`
   background: ${black66};
   z-index: 7000;
   display: block;
+  overflow-y: auto;
 `;
 
 export const ModalBox = styled.div`
@@ -34,7 +35,6 @@ export const ModalBox = styled.div`
   z-index: 7001;
   width: 700px;
   min-width: 200px;
-  max-height: 60%;
   top: 20%;
   left: 50%;
   padding: 15px 15px;

--- a/src/components/priorities-table/priorities-table.jsx
+++ b/src/components/priorities-table/priorities-table.jsx
@@ -62,20 +62,6 @@ const PrioritiesTable = ({priorities, userRoles, actions, pagination}) => {
 
   return (
     <PrioritiesTableWrapper isEmpty={isEmpty}>
-      {/* <div id="priorityInfoMessage">
-        <FontAwesomeIcon icon={faInfoCircle} fixedWidth />
-        Priorities are project specific labels that can be attached to stories.
-        {actionAllowed && (
-          <Button 
-            onClick={actions.createPriority}
-            label="Add Priority"
-            primary
-            small
-            startIcon={faPlus}
-            dataTestId="addPriorityButton"
-          />
-        )}
-      </div> */}
       {!isEmpty ? (
         <Fragment>
           <Table {...tableProps} />

--- a/src/components/priorities-table/priorities-table.jsx
+++ b/src/components/priorities-table/priorities-table.jsx
@@ -62,7 +62,7 @@ const PrioritiesTable = ({priorities, userRoles, actions, pagination}) => {
 
   return (
     <PrioritiesTableWrapper isEmpty={isEmpty}>
-      <div id="priorityInfoMessage">
+      {/* <div id="priorityInfoMessage">
         <FontAwesomeIcon icon={faInfoCircle} fixedWidth />
         Priorities are project specific labels that can be attached to stories.
         {actionAllowed && (
@@ -75,7 +75,7 @@ const PrioritiesTable = ({priorities, userRoles, actions, pagination}) => {
             dataTestId="addPriorityButton"
           />
         )}
-      </div>
+      </div> */}
       {!isEmpty ? (
         <Fragment>
           <Table {...tableProps} />

--- a/src/components/priorities-table/priorities-table.spec.jsx
+++ b/src/components/priorities-table/priorities-table.spec.jsx
@@ -40,29 +40,6 @@ describe("<PrioritiesTable />", () => {
     expect(component).toBeDefined();
   });
 
-  it("should render an info message about priorities", () => {
-    const {getByText} = render(<PrioritiesTable {...props} />);
-    expect(getByText("Priorities are project specific labels that can be attached to stories.")).toBeDefined();
-  });
-
-  it("should render an Add Priority button for managers and admins", () => {
-    const {getByTestId} = render(<PrioritiesTable {...props} />);
-    expect(getByTestId("addPriorityButton")).toBeDefined();
-  });
-
-  it("should not render the button for developers and viewers", () => {
-    props.userRoles = {isDeveloper: true, isViewer: true};
-    const {queryByTestId} = render(<PrioritiesTable {...props} />);
-    expect(queryByTestId("addPriorityButton")).toBeNull();
-  });
-
-  it("should call props.actions.createPriority when Add Priority is clicked", () => {
-    const {getByTestId} = render(<PrioritiesTable {...props} />);
-    const addButton = getByTestId("addPriorityButton");
-    fireEvent.click(addButton);
-    expect(props.actions.createPriority).toHaveBeenCalled();
-  });
-
   it("should render a message if there are no priorities to display", () => {
     props.priorities = [];
     const {getByText} = render(<PrioritiesTable {...props} />);

--- a/src/components/projects-table/projects-table.jsx
+++ b/src/components/projects-table/projects-table.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Table from "../table/table";
 import {TableValue} from "../table/table.styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {faArrowRight, faTrash, faBook, faUserPlus} from "@fortawesome/free-solid-svg-icons";
+import {faArrowRight, faTrash, faBook, faUserPlus, faCog} from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "../tooltip/tooltip";
 import {formatDate, getPermissionLevel} from "../../utils";
 import {ActionsWrapper, Action, LinkAction, PaginationSection} from "../table/table.styles";
@@ -13,7 +13,7 @@ import Pagination from "../pagination/pagination";
 const ProjectsTable = ({projects, actions, pagination}) => {
   const isEmpty = projects.length === 0;
   const _renderActions = (row) => {
-    const {deleteProject, addStory, addMember, viewProject} = actions;
+    const {addStory, addMember, viewProject, viewProjectConfigs} = actions;
     const {isAdmin, isManager, isDeveloper, isViewer} = row.roles;
     const adminAllowed = isAdmin;
     const managerAllowed = (isAdmin || isManager);
@@ -21,10 +21,6 @@ const ProjectsTable = ({projects, actions, pagination}) => {
     const viewerAllowed = (isAdmin || isManager || isDeveloper || isViewer);
     return (
       <ActionsWrapper>
-        <Action data-testid="action.deleteProject" highlightAction={adminAllowed} onClick={() => adminAllowed && deleteProject(row)}>
-          <FontAwesomeIcon icon={faTrash} fixedWidth />
-          {adminAllowed && <Tooltip text={"Delete Project"} />}
-        </Action>
         <Action data-testid="action.addMember" highlightAction={managerAllowed} onClick={() => managerAllowed && addMember(row, adminAllowed)}>
           <FontAwesomeIcon icon={faUserPlus} fixedWidth />
           {managerAllowed && <Tooltip text={"Add Member"} />}
@@ -33,7 +29,15 @@ const ProjectsTable = ({projects, actions, pagination}) => {
           <FontAwesomeIcon icon={faBook} fixedWidth />
           {developerAllowed && <Tooltip text={"Add Story"} />}
         </Action>
-        <LinkAction 
+        <LinkAction
+        data-testid="action.viewProjectConfigs" 
+        highlightAction={viewerAllowed} 
+        href={`/projects/${row.id}/configs`} 
+        onClick={(e) => {e.preventDefault(); if(viewerAllowed) return viewProjectConfigs(row)}}>
+          <FontAwesomeIcon icon={faCog} fixedWidth />
+          {viewerAllowed && <Tooltip text={"Manage Configs"} />}
+        </LinkAction>
+        <LinkAction
         data-testid="action.viewProject" 
         highlightAction={viewerAllowed} 
         href={`/projects/${row.id}`} 
@@ -104,10 +108,10 @@ const ProjectsTable = ({projects, actions, pagination}) => {
 ProjectsTable.propTypes = {
   projects: PropTypes.array.isRequired,
   actions: PropTypes.shape({
-    deleteProject: PropTypes.func.isRequired,
     addMember: PropTypes.func.isRequired,
     addStory: PropTypes.func.isRequired,
-    viewProject: PropTypes.func.isRequired
+    viewProject: PropTypes.func.isRequired,
+    viewProjectConfigs: PropTypes.func.isRequired
   }).isRequired,
   pagination: PropTypes.shape({
     page: PropTypes.number.isRequired,

--- a/src/components/projects-table/projects-table.jsx
+++ b/src/components/projects-table/projects-table.jsx
@@ -7,10 +7,10 @@ import {faArrowRight, faTrash, faBook, faUserPlus} from "@fortawesome/free-solid
 import Tooltip from "../tooltip/tooltip";
 import {formatDate, getPermissionLevel} from "../../utils";
 import {ActionsWrapper, Action, LinkAction, PaginationSection} from "../table/table.styles";
-import {DashboardProjectsTableWrapper} from "./dashboard-projects-table.styles";
+import {ProjectsTableWrapper} from "./projects-table.styles";
 import Pagination from "../pagination/pagination";
 
-const DashboardProjectsTable = ({projects, actions, pagination}) => {
+const ProjectsTable = ({projects, actions, pagination}) => {
   const isEmpty = projects.length === 0;
   const _renderActions = (row) => {
     const {deleteProject, addStory, addMember, viewProject} = actions;
@@ -46,7 +46,7 @@ const DashboardProjectsTable = ({projects, actions, pagination}) => {
   };
 
   const tableProps = {
-    dataTestId: "dashboardProjects",
+    dataTestId: "projectsTable",
     headers: [{
       label: "Name",
       keyName: "name",
@@ -76,7 +76,7 @@ const DashboardProjectsTable = ({projects, actions, pagination}) => {
   };
 
   const paginationProps = {
-    dataTestId: "dashboardProjectsPagination",
+    dataTestId: "projectsPagination",
     itemsPerPage: pagination && pagination.itemsPerPage,
     page: pagination && pagination.page,
     totalPages: pagination && pagination.totalPages,
@@ -84,7 +84,7 @@ const DashboardProjectsTable = ({projects, actions, pagination}) => {
   };
 
   return (
-    <DashboardProjectsTableWrapper isEmpty={isEmpty}>
+    <ProjectsTableWrapper isEmpty={isEmpty}>
       {!isEmpty ? (
         <Fragment>
           <Table {...tableProps} />
@@ -97,11 +97,11 @@ const DashboardProjectsTable = ({projects, actions, pagination}) => {
       ) : (
         <div>There are no projects to display</div>
       )}
-    </DashboardProjectsTableWrapper>
+    </ProjectsTableWrapper>
   );
 };
 
-DashboardProjectsTable.propTypes = {
+ProjectsTable.propTypes = {
   projects: PropTypes.array.isRequired,
   actions: PropTypes.shape({
     deleteProject: PropTypes.func.isRequired,
@@ -117,4 +117,4 @@ DashboardProjectsTable.propTypes = {
   })
 };
 
-export default DashboardProjectsTable;
+export default ProjectsTable;

--- a/src/components/projects-table/projects-table.spec.jsx
+++ b/src/components/projects-table/projects-table.spec.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import DashboardProjectsTable from "./dashboard-projects-table";
+import ProjectsTable from "./projects-table";
 import { render } from "../../test-utils";
 import {fireEvent} from "@testing-library/react";
 
-describe("<DashboardProjectsTable />", () => {
+describe("<ProjectsTable />", () => {
   let props;
   beforeEach(() => {
     props = {
@@ -41,21 +41,21 @@ describe("<DashboardProjectsTable />", () => {
   });
 
   it("should mount the component", () => {
-    const component = render(<DashboardProjectsTable {...props} />);
+    const component = render(<ProjectsTable {...props} />);
     expect(component).toBeDefined();
   });
 
   it("should render a message if there are no projects to display", () => {
     props.projects = [];
-    const {getByText} = render(<DashboardProjectsTable {...props} />);
+    const {getByText} = render(<ProjectsTable {...props} />);
     expect(getByText("There are no projects to display")).toBeDefined();
   });
 
   it("should render the expected headers", () => {
-    const {getByTestId, getByText} = render(<DashboardProjectsTable {...props}/>);
-    expect(getByTestId("dashboardProjects")).toBeDefined();
-    expect(getByTestId("dashboardProjects.table")).toBeDefined();
-    expect(getByTestId("dashboardProjects.tableHead")).toBeDefined();
+    const {getByTestId, getByText} = render(<ProjectsTable {...props}/>);
+    expect(getByTestId("projectsTable")).toBeDefined();
+    expect(getByTestId("projectsTable.table")).toBeDefined();
+    expect(getByTestId("projectsTable.tableHead")).toBeDefined();
     expect(getByText("Name")).toBeDefined();
     expect(getByText("Unique ID")).toBeDefined();
     expect(getByText("Visibility")).toBeDefined();
@@ -65,8 +65,8 @@ describe("<DashboardProjectsTable />", () => {
   });
 
   it("should render the project data for each header", () => {
-    const {getByTestId, getByText} = render(<DashboardProjectsTable {...props} />);
-    expect(getByTestId("dashboardProjects.tableBody")).toBeDefined();
+    const {getByTestId, getByText} = render(<ProjectsTable {...props} />);
+    expect(getByTestId("projectsTable.tableBody")).toBeDefined();
     // Row 1 should be-
     expect(getByText("Test Project 1")).toBeDefined();
     expect(getByText("test-id-1")).toBeDefined();;
@@ -83,7 +83,7 @@ describe("<DashboardProjectsTable />", () => {
   });
 
   it("should render the action buttons for each row", () => {
-    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const {getAllByTestId} = render(<ProjectsTable {...props} />);
     expect(getAllByTestId("action.deleteProject")).toHaveLength(2);
     expect(getAllByTestId("action.addStory")).toHaveLength(2);
     expect(getAllByTestId("action.addMember")).toHaveLength(2);
@@ -91,21 +91,21 @@ describe("<DashboardProjectsTable />", () => {
   });
 
   it("should not call an action method if clicked with insufficient permissions", () => {
-    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const {getAllByTestId} = render(<ProjectsTable {...props} />);
     const deleteAction = getAllByTestId("action.deleteProject")[1];
     fireEvent.click(deleteAction);
     expect(props.actions.deleteProject).not.toHaveBeenCalled();
   });
 
   it("should call an action method if clicked with sufficient permissions", () => {
-    const {getAllByTestId} = render(<DashboardProjectsTable {...props} />);
+    const {getAllByTestId} = render(<ProjectsTable {...props} />);
     const deleteAction = getAllByTestId("action.deleteProject")[0];
     fireEvent.click(deleteAction);
     expect(props.actions.deleteProject).toHaveBeenCalledWith(props.projects[0]);
   });
 
   it("should render the action tooltips if they are allowed", () => {
-    const {getAllByText} = render(<DashboardProjectsTable {...props}/>);
+    const {getAllByText} = render(<ProjectsTable {...props}/>);
     expect(getAllByText("Delete Project")).toHaveLength(1);
     expect(getAllByText("Add Story")).toHaveLength(2);
     expect(getAllByText("Add Member")).toHaveLength(1);
@@ -113,13 +113,13 @@ describe("<DashboardProjectsTable />", () => {
   });
 
   it("should render the pagination component", () => {
-    const {getByTestId} = render(<DashboardProjectsTable {...props}/>);
-    expect(getByTestId("dashboardProjectsPagination")).toBeDefined();
+    const {getByTestId} = render(<ProjectsTable {...props}/>);
+    expect(getByTestId("projectsPagination")).toBeDefined();
   });
 
   it("should call the getPage method when paginating", () => {
-    const {getByTestId} = render(<DashboardProjectsTable {...props}/>);
-    const nextPage = getByTestId("dashboardProjectsPagination.next");
+    const {getByTestId} = render(<ProjectsTable {...props}/>);
+    const nextPage = getByTestId("projectsPagination.next");
     fireEvent.click(nextPage);
     expect(props.pagination.getPage).toHaveBeenCalledWith(2);
   });

--- a/src/components/projects-table/projects-table.spec.jsx
+++ b/src/components/projects-table/projects-table.spec.jsx
@@ -26,10 +26,10 @@ describe("<ProjectsTable />", () => {
         createdOn: "2020-07-14T17:59:52.639Z"
       }],
       actions: {
-        deleteProject: jest.fn(),
         addMember: jest.fn(),
         addStory: jest.fn(),
-        viewProject: jest.fn()
+        viewProject: jest.fn(),
+        viewProjectConfigs: jest.fn()
       },
       pagination: {
         page: 1,
@@ -84,32 +84,32 @@ describe("<ProjectsTable />", () => {
 
   it("should render the action buttons for each row", () => {
     const {getAllByTestId} = render(<ProjectsTable {...props} />);
-    expect(getAllByTestId("action.deleteProject")).toHaveLength(2);
     expect(getAllByTestId("action.addStory")).toHaveLength(2);
     expect(getAllByTestId("action.addMember")).toHaveLength(2);
+    expect(getAllByTestId("action.viewProjectConfigs")).toHaveLength(2);
     expect(getAllByTestId("action.viewProject")).toHaveLength(2);
   });
 
   it("should not call an action method if clicked with insufficient permissions", () => {
     const {getAllByTestId} = render(<ProjectsTable {...props} />);
-    const deleteAction = getAllByTestId("action.deleteProject")[1];
-    fireEvent.click(deleteAction);
-    expect(props.actions.deleteProject).not.toHaveBeenCalled();
+    const addMember = getAllByTestId("action.addMember")[1];
+    fireEvent.click(addMember);
+    expect(props.actions.addMember).not.toHaveBeenCalled();
   });
 
   it("should call an action method if clicked with sufficient permissions", () => {
     const {getAllByTestId} = render(<ProjectsTable {...props} />);
-    const deleteAction = getAllByTestId("action.deleteProject")[0];
-    fireEvent.click(deleteAction);
-    expect(props.actions.deleteProject).toHaveBeenCalledWith(props.projects[0]);
+    const addMember = getAllByTestId("action.addMember")[0];
+    fireEvent.click(addMember);
+    expect(props.actions.addMember).toHaveBeenCalledWith(props.projects[0], true);
   });
 
   it("should render the action tooltips if they are allowed", () => {
     const {getAllByText} = render(<ProjectsTable {...props}/>);
-    expect(getAllByText("Delete Project")).toHaveLength(1);
     expect(getAllByText("Add Story")).toHaveLength(2);
     expect(getAllByText("Add Member")).toHaveLength(1);
     expect(getAllByText("View Project")).toHaveLength(2);
+    expect(getAllByText("Manage Configs")).toHaveLength(2);
   });
 
   it("should render the pagination component", () => {

--- a/src/components/projects-table/projects-table.styles.js
+++ b/src/components/projects-table/projects-table.styles.js
@@ -3,7 +3,7 @@ import {TableWrapper} from "../table/table.styles";
 import {PaginationWrapper} from "../pagination/pagination.styles";
 import {white, black1a} from "../../common-styles/variables";
 
-export const DashboardProjectsTableWrapper = styled.div`
+export const ProjectsTableWrapper = styled.div`
   position: relative;
   height: 775px;
   background-color: ${black1a};

--- a/src/components/story-modal/story-modal.styles.js
+++ b/src/components/story-modal/story-modal.styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import {SelectInputWrapper} from "../select-input/select-input.styles";
+import {TextAreaWrapper} from "../text-area/text-area.styles";
 
 export const StoryModalWrapper = styled.div`
   position: relative;
@@ -11,6 +11,12 @@ export const StoryModalWrapper = styled.div`
 
   & #priorityInput-wrapper {
     margin-bottom: 25px;
+  }
+
+  & ${TextAreaWrapper} {
+    & textarea {
+      height: 10em;
+    }
   }
 `;
 

--- a/src/components/text-area/text-area.styles.js
+++ b/src/components/text-area/text-area.styles.js
@@ -23,7 +23,7 @@ export const TextAreaWrapper = styled.div`
     min-width: 100%;
     min-height: ${textAreaHeight};
     height: ${textAreaHeight};
-    max-height: 17em;
+    max-height: 10em;
     border-radius: 5px;
     font-size: 16px;
     font-stretch: 100%;

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -101,10 +101,10 @@ const Dashboard = (props) => {
   const projectsTableProps = {
     projects,
     actions: {
-      deleteProject: (project) => setDeleteProject(project),
       addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
       viewProject: (project) => historyPush(`/projects/${project.id}`),
-      addStory: (project) => setNewStoryData({project})
+      addStory: (project) => setNewStoryData({project}),
+      viewProjectConfigs: (project) => historyPush(`/projects/${project.id}/configs`)
     },
     pagination: {
       itemsPerPage: projectsData && projectsData.itemsPerPage,

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -21,7 +21,7 @@ import StoryModal from "../../components/story-modal/story-modal";
 import {getDashboardProjects, getDashboardStories} from "../../store/actions/dashboard";
 import StoriesTable from "../../components/stories-table/stories-table";
 import SearchBar from "../../components/search-bar/search-bar";
-import {generateUrlWithQuery, generateObjectFromSearch, setTitle} from "../../utils";
+import {updateQueryString, generateObjectFromSearch, setTitle, onHeaderClick} from "../../utils";
 
 const Dashboard = (props) => {
   setTitle("Dashboard");
@@ -71,10 +71,10 @@ const Dashboard = (props) => {
 
     // If the initial query-string had values that changed (page > totalPages), update the query-string.
     if(query.projectsPage && projectsResponse && projectsResponse.page.toString() !== query.projectsPage)
-      _updateQueryString("projectsPage", projectsResponse.page);
+      updateQueryString("projectsPage", projectsResponse.page);
   
     if(query.storiesPage && storiesResponse && storiesResponse.page.toString() !== query.storiesPage)
-      _updateQueryString("storiesPage", storiesResponse.page);
+      updateQueryString("storiesPage", storiesResponse.page);
   };
   useEffect(() => {
     _loadData();
@@ -86,7 +86,7 @@ const Dashboard = (props) => {
     if(!projectsResponse.error)
       setProjectsData(projectsResponse);
     
-    _updateQueryString("projectsPage", projectsResponse.page);
+    updateQueryString("projectsPage", projectsResponse.page);
   };
 
   const _refreshStories = async() => {
@@ -94,11 +94,6 @@ const Dashboard = (props) => {
     const storiesResponse = await getDashboardStories(page, itemsPerPage, storySearchData.searchedValue);
     if(!storiesResponse.error)
       setStoriesData(storiesResponse);
-  };
-
-  const _updateQueryString = (key, value) => {
-    const newUrl = generateUrlWithQuery(key, value);
-    history.replaceState({path: newUrl}, "", newUrl);
   };
 
   const projects = projectsData && projectsData.projects;
@@ -122,7 +117,7 @@ const Dashboard = (props) => {
         if(!response.error)
           setProjectsData(response);
         
-        _updateQueryString("projectsPage", page);
+        updateQueryString("projectsPage", page);
       }
     }
   };
@@ -143,7 +138,7 @@ const Dashboard = (props) => {
         if(!response.error)
           setStoriesData(response);
         
-        _updateQueryString("storiesPage", page);
+        updateQueryString("storiesPage", page);
       }
     }
   };
@@ -169,26 +164,26 @@ const Dashboard = (props) => {
       inputValue: value
     }),
     search: async(value) => {
-      _updateQueryString("projectSearch", value ? value : null);
+      updateQueryString("projectSearch", value ? value : null);
       setProjectSearchData({
         ...projectSearchData,
         searchedValue: value
       });
       const {itemsPerPage} = projectsData;
       const projectsResponse = await getDashboardProjects(1, itemsPerPage, value);
-      _updateQueryString("projectsPage", 1);
+      updateQueryString("projectsPage", 1);
       if(!projectsResponse.error)
         setProjectsData(projectsResponse);
     },
     clear: async() => {
-      _updateQueryString("projectSearch", null);
+      updateQueryString("projectSearch", null);
       setProjectSearchData({
         inputValue: "",
         searchedValue: ""
       });
       const {itemsPerPage} = projectsData;
       const projectsResponse = await getDashboardProjects(1, itemsPerPage);
-      _updateQueryString("projectsPage", 1);
+      updateQueryString("projectsPage", 1);
       if(!projectsResponse.error)
         setProjectsData(projectsResponse);
     }
@@ -206,36 +201,29 @@ const Dashboard = (props) => {
       inputValue: value
     }),
     search: async(value) => {
-      _updateQueryString("storySearch", value ? value : null);
+      updateQueryString("storySearch", value ? value : null);
       setStorySearchData({
         ...storySearchData,
         searchedValue: value
       });
       const {itemsPerPage} = storiesData;
       const storiesResponse = await getDashboardStories(1, itemsPerPage, value);
-      _updateQueryString("storiesPage", 1);
+      updateQueryString("storiesPage", 1);
       if(!storiesResponse.error)
         setStoriesData(storiesResponse);
     },
     clear: async() => {
-      _updateQueryString("storySearch", null);
+      updateQueryString("storySearch", null);
       setStorySearchData({
         inputValue: "",
         searchedValue: ""
       });
       const {itemsPerPage} = storiesData;
       const storiesResponse = await getDashboardStories(1, itemsPerPage);
-      _updateQueryString("storiesPage", 1);
+      updateQueryString("storiesPage", 1);
       if(!storiesResponse.error)
         setStoriesData(storiesResponse);
     }
-  };
-
-  const _onHeaderClick = (headerIndex) => {
-    if(headerIndex === 0)
-      return _updateQueryString("activeTab", null);
-    
-    _updateQueryString("activeTab", headerIndex);
   };
 
   return (
@@ -246,7 +234,7 @@ const Dashboard = (props) => {
         <Fragment>
           <PageHeader text="Dashboard" textCenter dataTestId="dashboardHeader" />
           <ActionsMenu {...actionsMenuProps} />
-          <Tabs dataTestId="dashboardTabs" tabOverride={query.activeTab} onHeaderClick={_onHeaderClick}>
+          <Tabs dataTestId="dashboardTabs" tabOverride={query.activeTab} onHeaderClick={onHeaderClick}>
             <Tabs.TabHeaders>
               <Tabs.Header>My Projects</Tabs.Header>
               <Tabs.Header>My Stories</Tabs.Header>

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -11,7 +11,7 @@ import {getAllPriorityNames} from "../../store/actions/priority";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
-import ProjectsTable from "../../components/dashboard-projects-table/dashboard-projects-table";
+import ProjectsTable from "../../components/projects-table/projects-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import {push} from "connected-react-router";
 import MembershipModal from "../../components/membership-modal/membership-modal";

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -168,15 +168,6 @@ describe("<Dashboard />", () => {
     expect(getByTestId("projectsTable")).toBeDefined();
   });
 
-  it("should render the DeleteModal if the delete project action is clicked", async() => {
-    const {getAllByTestId, queryByTestId} = render(<Dashboard {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    const deleteButton = getAllByTestId("action.deleteProject")[0];
-    expect(queryByTestId("projectDeleteModal.wrapper")).toBeNull();
-    fireEvent.click(deleteButton);
-    expect(queryByTestId("projectDeleteModal.wrapper")).toBeDefined();
-  });
-
   it("should render the MembershipModal if the add member action is clicked", async() => {
     const {getAllByTestId, queryByTestId} = render(<Dashboard {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
@@ -210,6 +201,20 @@ describe("<Dashboard />", () => {
       payload: {
         method: "push",
         args: [`/projects/${projectsResponse.projects[0].id}`]
+      }
+    });
+  });
+
+  it("should call the push redux action when the manage configs action is clicked", async() => {
+    const {getAllByTestId} = render(<Dashboard {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const configsButton = getAllByTestId("action.viewProjectConfigs")[0];
+    fireEvent.click(configsButton);
+    expect(store.dispatch).toHaveBeenLastCalledWith({
+      type: "@@router/CALL_HISTORY_METHOD",
+      payload: {
+        method: "push",
+        args: [`/projects/${projectsResponse.projects[0].id}/configs`]
       }
     });
   });

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -165,7 +165,7 @@ describe("<Dashboard />", () => {
   it("should render the projects table if there are projects to display", async() => {
     const {getByTestId} = render(<Dashboard {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(getByTestId("dashboardProjects")).toBeDefined();
+    expect(getByTestId("projectsTable")).toBeDefined();
   });
 
   it("should render the DeleteModal if the delete project action is clicked", async() => {

--- a/src/containers/project-configs/project-configs.jsx
+++ b/src/containers/project-configs/project-configs.jsx
@@ -1,0 +1,174 @@
+import React, {useState, useEffect, Fragment} from "react";
+import PropTypes from "prop-types";
+import {connect} from "react-redux";
+import {ProjectConfigsWrapper} from "./project-configs.styles";
+import {PageError} from "../../common-styles/base";
+import {updateQueryString, generateObjectFromSearch, setTitle, onHeaderClick } from "../../utils";
+import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
+import {getPriorities, createPriority, deletePriority, updatePriority} from "../../store/actions/priority";
+import {getProject} from "../../store/actions/project";
+import Tabs from "../../components/tabs/tabs";
+import PrioritiesTable from "../../components/priorities-table/priorities-table";
+import PageHeader from "../../components/page-header/page-header";
+import PriorityModal from "../../components/priority-modal/priority-modal";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faInfoCircle, faPlus} from "@fortawesome/free-solid-svg-icons";
+import ActionsMenu from "../../components/actions-menu/actions-menu";
+import Button from "../../components/button/button";
+import {push} from "connected-react-router";
+
+const ProjectConfigs = (props) => {
+  setTitle("Project Configs");
+  const query = generateObjectFromSearch(props.location.search);
+  const projectId = props.match.params.projectId;
+  const [pageError, setPageError] = useState(undefined);
+  const [projectData, setProjectData] = useState(undefined);
+  const [prioritiesData, setPrioritiesData] = useState(undefined);
+  const [showAddPriorityModal, setShowAddPriorityModal] = useState(false);
+  const [editPriorityData, setEditPriorityData] = useState({});
+
+  const _loadData = async() => {
+    const projectResponse = await props.getProject(projectId);
+    const prioritiesResponse = await props.getPriorities(projectId, query.prioritiesPage);
+
+    if(projectResponse && projectResponse.error)
+      return setPageError(projectResponse.error);
+    if(prioritiesResponse && prioritiesResponse.error)
+      return setPageError(prioritiesResponse.error);
+
+    if(query.prioritiesPage && prioritiesResponse && prioritiesResponse.page.toString() !== query.prioritiesPage)
+      updateQueryString("prioritiesPage", prioritiesResponse.page);
+
+    setProjectData(projectResponse);
+    setPrioritiesData(prioritiesResponse);
+  };
+
+  useEffect(() => {
+    _loadData();
+  }, []);
+
+  const _reloadPriorities = async() => {
+    const {itemsPerPage, page} = prioritiesData;
+    const response = await props.getPriorities(projectId, page, itemsPerPage);
+    if(response && response.error)
+      return setPageError(response.error);
+    
+    setPrioritiesData(response);
+  };
+
+  const project = projectData && projectData.project;
+  const userRoles = projectData && projectData.userRoles || {};
+  const priorities = prioritiesData && prioritiesData.priorities;
+  const actionsMenuProps = {
+    dataTestId: "projectConfigsActionsMenu",
+    menuItems: [{
+      icon: faPlus,
+      label: "Add Priority",
+      onClick: () => setShowAddPriorityModal(true)
+    }]
+  };
+  return (
+    <ProjectConfigsWrapper>
+      {pageError ? (
+        <PageError>{pageError}</PageError>
+      ) : 
+      (!projectData || !prioritiesData) ? (
+        <LoadingSpinner alignCenter dataTestId="projectConfigsLoader" message={`Loading project configs`} />
+      ) : (
+        <Fragment>
+          <PageHeader text={`Configs - ${project.name}`} dataTestId="projectConfigsHeader" textCenter/>
+          <div id="configsInfoMessage">
+            <FontAwesomeIcon icon={faInfoCircle} fixedWidth />
+            Configs are project specific values that can be associated with stories.
+            <Button 
+              primary
+              small
+              label="View Project Details"
+              onClick={() => props.historyPush(`/projects/${project.id}`)}
+              dataTestId="projectDetailsButton"
+            />
+          </div>
+          {userRoles && (userRoles.isAdmin || userRoles.isManager) && (
+            <ActionsMenu {...actionsMenuProps} />
+          )}
+          <Tabs dataTestId="projectConfigsTabs" tabOverride={query.activeTab} onHeaderClick={onHeaderClick}>
+            <Tabs.TabHeaders>
+              <Tabs.Header>Priorities</Tabs.Header>
+            </Tabs.TabHeaders>
+            <Tabs.TabPanels>
+              <Tabs.Panel>
+                <PrioritiesTable
+                  priorities={priorities}
+                  userRoles={userRoles}
+                  actions={{
+                    createPriority: () => setShowAddPriorityModal(true),
+                    deletePriority: async(priority) => {
+                      await props.deletePriority({...priority, project});
+                      _reloadPriorities();
+                    },
+                    editPriority: (priority) => setEditPriorityData(priority)
+                  }}
+                  pagination={{
+                    itemsPerPage: prioritiesData && prioritiesData.itemsPerPage,
+                    page: prioritiesData && prioritiesData.page,
+                    totalPages: prioritiesData && prioritiesData.totalPages,
+                    getPage: async(page) => {
+                      if(page === prioritiesData.page)
+                        return;
+                      updateQueryString("prioritiesPage", page);
+                      const response = await props.getPriorities(projectId, page, prioritiesData.itemsPerPage);
+                      if(response.error)
+                        return setPageError(response.error);
+                      
+                      setPrioritiesData(response);
+                    }
+                  }}
+                />
+              </Tabs.Panel>
+            </Tabs.TabPanels>
+          </Tabs>
+        </Fragment>
+      )}
+      {showAddPriorityModal && (
+        <PriorityModal 
+          onClose={() => setShowAddPriorityModal(false)}
+          onSubmit={props.createPriority}
+          requestInProgress={props.priorityIsLoading}
+          project={project}
+          refresh={_reloadPriorities}
+        />
+      )}
+      {editPriorityData.id && (
+        <PriorityModal
+          onClose={() => setEditPriorityData({})}
+          onSubmit={props.updatePriority}
+          requestInProgress={props.priorityIsLoading}
+          project={project}
+          priority={editPriorityData}
+          refresh={_reloadPriorities}
+        />
+      )}
+    </ProjectConfigsWrapper>
+  );
+};
+
+ProjectConfigs.propTypes = {
+  getPriorities: PropTypes.func.isRequired,
+  createPriority: PropTypes.func.isRequired,
+  deletePriority: PropTypes.func.isRequired,
+  updatePriority: PropTypes.func.isRequired,
+  priorityIsLoading: PropTypes.bool.isRequired,
+  getProject: PropTypes.func.isRequired,
+  historyPush: PropTypes.func.isRequired
+};
+
+export default connect((state) => ({
+  priorityIsLoading: state.priority.isLoading
+}), {
+  getPriorities,
+  createPriority,
+  deletePriority,
+  updatePriority,
+  getProject,
+  historyPush: push
+})(ProjectConfigs);

--- a/src/containers/project-configs/project-configs.spec.jsx
+++ b/src/containers/project-configs/project-configs.spec.jsx
@@ -1,0 +1,190 @@
+import React from "react";
+import ProjectConfigs from "./project-configs";
+import { render, mockStore } from "../../test-utils";
+import {waitFor, fireEvent} from "@testing-library/react";
+
+describe("<ProjectConfigs />", () => {
+  let store;
+  let props;
+  let projectsResponse = {
+    project: {
+      id: "testProjectId",
+      name: "Unit Test Project"
+    },
+    userRoles: {
+      isAdmin: true
+    }
+  };
+  let prioritiesResponse = {
+    page: 1,
+    totalPages: 10,
+    itemsPerPage: 10,
+    priorities: [{
+      id: "testPriority1",
+      name: "Test Priority 1",
+      color: "#9a6c1d",
+      createdOn: "2020-08-28T18:40:03.471Z"
+    }, {
+      id: "testPriority2",
+      name: "Test Priority 2",
+      color: "#000000",
+      createdOn: "2020-08-28T18:40:03.471Z"
+    }]
+  };
+  beforeEach(() => {
+    props = {
+      match: {
+        params: {projectId: "testProjectId"}
+      },
+      location: {
+        search: ""
+      }
+    };
+    store = mockStore({
+      priority: {isLoading: false}
+    });
+
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(projectsResponse);
+    store.dispatch.mockReturnValueOnce(prioritiesResponse);
+  });
+
+  it("should mount the component", async() => {
+    const component = render(<ProjectConfigs {...props} />, store);
+    expect(component).toBeDefined();
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+  });
+
+  it("should render a PageError if the API returns an error", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce({error: "something went wrong"});
+    store.dispatch.mockReturnValueOnce(prioritiesResponse);
+    const {queryByText} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByText("something went wrong")).toBeDefined();
+  });
+
+  it("should render a LoadingSpinner while awaiting initial API data", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+    const {queryByText, getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("projectConfigsLoader")).toBeDefined();
+    expect(queryByText("Loading project configs")).toBeDefined();
+  });
+
+  it("should render the expected page header", async() => {
+    const {queryByText, getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("projectConfigsHeader")).toBeDefined();
+    expect(queryByText("Configs - Unit Test Project")).toBeDefined();
+  });
+
+  it("should render an info message about project configs", async() => {
+    const {queryByText} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByText("Configs are project specific values that can be associated with stories.")).toBeDefined();
+  });
+
+  it("should render a View Project Details button with the info message", async() => {
+    const {queryByText, queryByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("projectDetailsButton")).toBeDefined();
+    expect(queryByText("View Project Details")).toBeDefined();
+  });
+
+  it("should dispatch a redux push action to go to project details on button click", async() => {
+    const {getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const detailsButton = getByTestId("projectDetailsButton");
+    fireEvent.click(detailsButton);
+    expect(store.dispatch).toHaveBeenCalledTimes(3);
+    expect(store.dispatch).toHaveBeenLastCalledWith({
+      payload: {
+        args: [`/projects/${projectsResponse.project.id}`],
+        method: "push"
+      },
+      type: "@@router/CALL_HISTORY_METHOD"
+    });
+  });
+
+  it("should not render an actions menu for developers or viewers", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce({project: projectsResponse.project, userRoles: {isDeveloper: true, isViewer: true}});
+    store.dispatch.mockReturnValueOnce(prioritiesResponse);
+    const {queryByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("projectConfigsActionsMenu")).toBeNull();
+  });
+
+  it("should render an actions menu for admins or managers", async() => {
+    const {queryByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("projectConfigsActionsMenu")).toBeDefined();
+  });
+
+  it("should render an action menu item to Add Priority", async() => {
+    const {queryByText, getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const actionsMenu = getByTestId("projectConfigsActionsMenu");
+    expect(queryByText("Add Priority")).toBeNull();
+    fireEvent.click(actionsMenu);
+    expect(queryByText("Add Priority")).toBeDefined();
+  });
+
+  it("should render the PriorityModal on add priority action click", async() => {
+    const {getByText, getByTestId, queryByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(queryByTestId("projectConfigsActionsMenu")).toBeDefined();
+    const actionsMenu = getByTestId("projectConfigsActionsMenu");
+    fireEvent.click(actionsMenu);
+    const actionItem = getByText("Add Priority");
+    expect(queryByTestId("priorityModal.wrapper")).toBeNull();
+    fireEvent.click(actionItem);
+    expect(queryByTestId("priorityModal.wrapper")).toBeDefined();
+  });
+
+  it("should render the Tabs component and expected headers", async() => {
+    const {queryByText, getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("projectConfigsTabs")).toBeDefined();
+    expect(queryByText("Priorities")).toBeDefined();
+  });
+
+  it("should render a message if a project has no priorities", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(projectsResponse);
+    store.dispatch.mockReturnValueOnce({...prioritiesResponse, priorities: []});
+    const {getByText} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByText("This project currently has no priorities.")).toBeDefined();
+  });
+
+  it("should render a priorities table with expected headers", async() => {
+    const {getByText, getAllByText, getByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    expect(getByTestId("prioritiesTable.table")).toBeDefined();
+    expect(getByTestId("prioritiesTable.tableHead")).toBeDefined();
+    expect(getByText("Priority")).toBeDefined();
+    expect(getByText("Unique ID")).toBeDefined();
+    expect(getByText("Created On")).toBeDefined();
+    expect(getAllByText("Actions")).toHaveLength(2);
+  });
+
+  it("should render the PriorityModal when the edit priority table action is clicked", async() => {
+    const {getAllByTestId, queryByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const editAction = getAllByTestId("action.editPriority")[0];
+    expect(queryByTestId("priorityModal.wrapper")).toBeNull();
+    fireEvent.click(editAction);
+    expect(queryByTestId("priorityModal.wrapper")).toBeDefined();
+  });
+
+  it("should call the deletePriority redux action when the delete priority table action is clicked", async() => {
+    const {getAllByTestId} = render(<ProjectConfigs {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
+    const deleteAction = getAllByTestId("action.deletePriority")[0];
+    fireEvent.click(deleteAction);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
+  });
+});

--- a/src/containers/project-configs/project-configs.styles.js
+++ b/src/containers/project-configs/project-configs.styles.js
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import {Spinner} from "../../components/loading-spinner/loading-spinner.styles";
+import {TabsWrapper} from "../../components/tabs/tabs.styles";
+import {ActionsWrapper} from "../../components/actions-menu/actions-menu.styles";
+import {tertiaryBlue26} from "../../common-styles/variables";
+import {ButtonWrapper} from "../../components/button/button.styles";
+
+export const ProjectConfigsWrapper = styled.div`
+  position: relative;
+  width: 100%;
+
+  & #configsInfoMessage {
+    font-size: 20px;
+    padding: 15px 25px;
+    background-color: ${tertiaryBlue26};
+    margin-bottom: 30px;
+    border-radius: 5px;
+    margin-left: 50px;
+    margin-right: 50px;
+    margin-top: 30px;
+    & ${ButtonWrapper} {
+      display: inline-block;
+      float: right;
+      & button {
+        border-radius: 5px;
+      }
+    }
+  }
+
+  & ${TabsWrapper} {
+    padding-top: 0;
+    padding-bottom: 30px;
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+
+  & ${Spinner} {
+    padding-top: 35px;
+  }
+
+  & ${ActionsWrapper} {
+    top: 190px;
+  }
+`;

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -21,7 +21,7 @@ import {PageError} from "../../common-styles/base";
 import MembershipsTable from "../../components/memberships-table/memberships-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import MembershipModal from "../../components/membership-modal/membership-modal";
-import { faTrash, faEdit, faUserTimes, faUserPlus, faBook } from "@fortawesome/free-solid-svg-icons";
+import { faTrash, faEdit, faUserTimes, faUserPlus, faBook, faCog } from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
 import {push} from "connected-react-router";
 import {showNotification} from "../../store/actions/notification";
@@ -177,11 +177,18 @@ const ProjectDetails = (props) => {
   const actionsMenuProps = {
     dataTestId: "projectDetailsActionsMenu",
     menuItems: [{
+      icon: faCog,
+      label: "Manage Configs",
+      onClick: () => historyPush(`/projects/${project.id}/configs`)
+    }]
+  };
+  if(userRoles && (userRoles.isManager || userRoles.isAdmin || userRoles.isDeveloper)) {
+    actionsMenuProps.menuItems = actionsMenuProps.menuItems.concat([{
       icon: faBook,
       label: "New Story",
       onClick: () => setShowStoryModal(true)
-    }]
-  };
+    }]);
+  }
   if(userRoles && (userRoles.isManager || userRoles.isAdmin)) {
     actionsMenuProps.menuItems = actionsMenuProps.menuItems.concat([{
       icon: faEdit,
@@ -287,7 +294,7 @@ const ProjectDetails = (props) => {
         (
           <Fragment>
             <PageHeader text={`Project - ${project.name}`} dataTestId="projectDetailsHeader" textCenter/>
-            {userRoles && (userRoles.isAdmin || userRoles.isManager || userRoles.isDeveloper) && (
+            {userRoles && (userRoles.isAdmin || userRoles.isManager || userRoles.isDeveloper || userRoles.isViewer) && (
               <ActionsMenu {...actionsMenuProps} />
             )}
             <Tabs dataTestId="projectDetailsTabs" tabOverride={query.activeTab} onHeaderClick={onHeaderClick}>

--- a/src/containers/project-details/project-details.jsx
+++ b/src/containers/project-details/project-details.jsx
@@ -29,7 +29,7 @@ import ActionsMenu from "../../components/actions-menu/actions-menu";
 import PageHeader from "../../components/page-header/page-header";
 import StoriesTable from "../../components/stories-table/stories-table";
 import StoryModal from "../../components/story-modal/story-modal";
-import {generateUrlWithQuery, generateObjectFromSearch, formatDate, setTitle} from "../../utils";
+import {updateQueryString, generateObjectFromSearch, formatDate, setTitle, onHeaderClick} from "../../utils";
 import SearchBar from "../../components/search-bar/search-bar";
 import MarkdownText from "../../components/markdown-text/markdown-text";
 
@@ -95,10 +95,10 @@ const ProjectDetails = (props) => {
 
     // If the initial query-string had values that changed (page > totalPages), update the query-string.
     if(query.membersPage && membershipResponse && membershipResponse.page.toString() !== query.membersPage)
-      _updateQueryString("membersPage", membershipResponse.page);
+      updateQueryString("membersPage", membershipResponse.page);
     
     if(query.storiesPage && storiesResponse && storiesResponse.page.toString() !== query.storiesPage)
-      _updateQueryString("storiesPage", storiesResponse.page);
+      updateQueryString("storiesPage", storiesResponse.page);
 
     setProjectData(projectResponse);
     setMembershipsData(membershipResponse);
@@ -139,11 +139,6 @@ const ProjectDetails = (props) => {
     _loadData();
   }, []);
 
-  const _updateQueryString = (key, value) => {
-    const newUrl = generateUrlWithQuery(key, value);
-    history.replaceState({path: newUrl}, "", newUrl);
-  }
-
   // Props that will be utilized in the membership tab's Pagination component.
   const membershipsPagination = {
     itemsPerPage: membershipsData && membershipsData.itemsPerPage,
@@ -152,7 +147,7 @@ const ProjectDetails = (props) => {
     getPage: async(page) => {
       if(page === membershipsData.page)
         return;
-      _updateQueryString("membersPage", page);
+      updateQueryString("membersPage", page);
       const response = await getMemberships(projectId, page, membershipsData.itemsPerPage, memberSearchData.searchedValue);
       if(response.error)
         return setPageError(response.error);
@@ -168,7 +163,7 @@ const ProjectDetails = (props) => {
     getPage: async(page) => {
       if(page === storiesData.page)
         return;
-      _updateQueryString("storiesPage", page);
+      updateQueryString("storiesPage", page);
       const response = await getStories(projectId, page, storiesData.itemsPerPage, storySearchData.searchedValue);
       if(response.error)
         return setPageError(response.error);
@@ -219,26 +214,26 @@ const ProjectDetails = (props) => {
       inputValue: value
     }),
     search: async(value) => {
-      _updateQueryString("memberSearch", value ? value : null);
+      updateQueryString("memberSearch", value ? value : null);
       setMemberSearchData({
         ...memberSearchData,
         searchedValue: value
       });
       const {itemsPerPage} = membershipsData;
       const membershipsResponse = await getMemberships(projectId, 1, itemsPerPage, value);
-      _updateQueryString("membersPage", 1);
+      updateQueryString("membersPage", 1);
       if(!membershipsResponse.error)
         setMembershipsData(membershipsResponse);
     },
     clear: async() => {
-      _updateQueryString("memberSearch", null);
+      updateQueryString("memberSearch", null);
       setMemberSearchData({
         inputValue: "",
         searchedValue: ""
       });
       const {itemsPerPage} = membershipsData;
       const membershipsResponse = await getMemberships(projectId, 1, itemsPerPage);
-      _updateQueryString("membersPage", 1);
+      updateQueryString("membersPage", 1);
       if(!membershipsResponse.error)
         setMembershipsData(membershipsResponse);
     }
@@ -256,36 +251,29 @@ const ProjectDetails = (props) => {
       inputValue: value
     }),
     search: async(value) => {
-      _updateQueryString("storySearch", value ? value : null);
+      updateQueryString("storySearch", value ? value : null);
       setStorySearchData({
         ...storySearchData,
         searchedValue: value
       });
       const {itemsPerPage} = storiesData;
       const storiesResponse = await getStories(projectId, 1, itemsPerPage, value);
-      _updateQueryString("storiesPage", 1);
+      updateQueryString("storiesPage", 1);
       if(!storiesResponse.error)
         setStoriesData(storiesResponse);
     },
     clear: async() => {
-      _updateQueryString("storySearch", null);
+      updateQueryString("storySearch", null);
       setStorySearchData({
         inputValue: "",
         searchedValue: ""
       });
       const {itemsPerPage} = storiesData;
       const storiesResponse = await getStories(projectId, 1, itemsPerPage);
-      _updateQueryString("storiesPage", 1);
+      updateQueryString("storiesPage", 1);
       if(!storiesResponse.error)
         setStoriesData(storiesResponse);
     }
-  };
-
-  const _onHeaderClick = (headerIndex) => {
-    if(headerIndex === 0)
-      return _updateQueryString("activeTab", null);
-    
-    _updateQueryString("activeTab", headerIndex);
   };
 
   return (
@@ -302,7 +290,7 @@ const ProjectDetails = (props) => {
             {userRoles && (userRoles.isAdmin || userRoles.isManager || userRoles.isDeveloper) && (
               <ActionsMenu {...actionsMenuProps} />
             )}
-            <Tabs dataTestId="projectDetailsTabs" tabOverride={query.activeTab} onHeaderClick={_onHeaderClick}>
+            <Tabs dataTestId="projectDetailsTabs" tabOverride={query.activeTab} onHeaderClick={onHeaderClick}>
               <Tabs.TabHeaders>
                 <Tabs.Header>Details</Tabs.Header>
                 <Tabs.Header>Members</Tabs.Header>

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -311,15 +311,37 @@ describe("<ProjectDetails />", () => {
     expect(getByText("Actions")).toBeDefined();
   });
 
-  it("should not render the actions menu component for viewers", async() => {
+  it("should not render the actions menu component for users with no permissions", async() => {
     store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isViewer: true}}));
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: null}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
     const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(queryByTestId("projectDetailsActionsMenu")).toBeNull();
     expect(queryByText("Actions")).toBeNull();
+  });
+
+  it("should render the `Manage Configs` action if the user has viewer permissions", async() => {
+    store.dispatch = jest.fn();
+    store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isViewer: true}}));
+    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
+    store.dispatch.mockReturnValueOnce(mockStoriesResponse);
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    expect(getByText("Manage Configs")).toBeDefined();
+  });
+
+  it("should dispatch a redux push action when `Manage Configs` is clicked", async() => {
+    const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
+    const actionsMenu = getByTestId("projectDetailsActionsMenu");
+    fireEvent.click(actionsMenu);
+    const configsActions = getByText("Manage Configs");
+    fireEvent.click(configsActions);
+    expect(store.dispatch).toHaveBeenCalledTimes(4);
   });
   
   it("should render the 'Delete Project' action if the user has admin permissions", async() => {

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -87,12 +87,7 @@ describe("<ProjectDetails />", () => {
       createdOn: "2019-01-13T17:59:52.639Z"
     }]
   };
-  const mockPrioritiesResponse = {
-    page: 1,
-    totalPages: 1,
-    itemsPerPage: 10,
-    priorities: []
-  };
+
   beforeEach(() => {
     props = {
       match: {
@@ -118,22 +113,18 @@ describe("<ProjectDetails />", () => {
       },
       story: {
         isLoading: false
-      },
-      priority: {
-        isLoading: false
       }
     });
     store.dispatch = jest.fn();
     store.dispatch.mockReturnValueOnce(mockProjectResponse);
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
   });
 
   it("should mount the component", async() => {
     const component = render(<ProjectDetails {...props} />, store);
     expect(component).toBeDefined();
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
   });
 
   it("should render the loading spinner when awaiting API data", async() => {
@@ -141,39 +132,37 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(undefined);
     store.dispatch.mockReturnValueOnce(undefined);
     store.dispatch.mockReturnValueOnce(undefined);
-    store.dispatch.mockReturnValueOnce(undefined);
     const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByTestId("projectDetailsLoader")).toBeDefined();
     expect(getByText("Loading project details")).toBeDefined();
   });
 
   it("should render the project details page header", async() => {
     const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByTestId("projectDetailsHeader")).toBeDefined();
     expect(getByText(`Project - Unit Test Project`)).toBeDefined();
   });
 
-  it("should render the project details, members, backlog, and priorities tabs", async() => {
+  it("should render the project details, members, and backlog tabs", async() => {
     const {getByTestId, getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByTestId("projectDetailsTabs")).toBeDefined();
     expect(getByText("Details")).toBeDefined();
     expect(getByText("Members")).toBeDefined();
     expect(getByText("Backlog")).toBeDefined();
-    expect(getByText("Priorities")).toBeDefined();
   });
 
   it("should render the project ID under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("testProjectId")).toBeDefined();
   });
 
   it("should render the project name under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Unit Test Project")).toBeDefined();
   });
 
@@ -187,21 +176,20 @@ describe("<ProjectDetails />", () => {
     });
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Public")).toBeDefined();
   });
 
   it("should render the private label under the details tab if the project is private", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Private")).toBeDefined();
   });
 
   it("should render the project description, if present, under the details tab", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Description")).toBeDefined();
     expect(getByText("this is a test description")).toBeDefined();
     expect(getByTestId("projectMarkdownText")).toBeDefined();
@@ -215,23 +203,22 @@ describe("<ProjectDetails />", () => {
     });
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Description")).toBeDefined();
     expect(getByText("This project has no description.")).toBeDefined();
   });
 
   it("should render the project create date under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Create Date")).toBeDefined();
     expect(getByText("Aug 1, 2020")).toBeDefined();
   });
 
   it("should render the project update date under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Last Modified")).toBeDefined();
     expect(getByText("Aug 5, 2020")).toBeDefined();
   });
@@ -247,22 +234,21 @@ describe("<ProjectDetails />", () => {
     });
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {queryByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(queryByText("Last Modified")).toBeNull();
   });
 
   it("should render the project total members under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Total Members")).toBeDefined();
     expect(getByText("15")).toBeDefined();
   });
 
   it("should render the project total stories under the details tab", async() => {
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("Total Stories")).toBeDefined();
     expect(getByText("150")).toBeDefined();
   });
@@ -271,9 +257,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch = jest.fn().mockReturnValueOnce({error: "something went wrong"});
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByText("something went wrong")).toBeDefined();
   });
 
@@ -281,9 +266,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch = jest.fn().mockReturnValueOnce(mockProjectResponse);
     store.dispatch.mockReturnValueOnce({...mockMembershipsResponse, memberships: []});
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, queryByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     expect(queryByText("There are no memberships to display")).toBeNull();
     fireEvent.click(membersTab);
@@ -292,7 +276,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render a the memberships table is the members tab is clicked", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     fireEvent.click(membersTab);
     expect(getByTestId("projectMemberships")).toBeDefined();
@@ -300,7 +284,7 @@ describe("<ProjectDetails />", () => {
 
   it("should show the delete membership modal if the action is clicked with sufficient permission", async() => {
     const {getByText, getAllByTestId, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     fireEvent.click(membersTab);
     const deleteAction = getAllByTestId("action.deleteMembership")[1];
@@ -311,7 +295,7 @@ describe("<ProjectDetails />", () => {
 
   it("should show the edit membership modal if the action is clicked with sufficient permission", async() => {
     const {getByText, getAllByTestId, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     fireEvent.click(membersTab);
     const editAction = getAllByTestId("action.editMembership")[1];
@@ -322,7 +306,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render the actions menu component for admins/managers", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(getByTestId("projectDetailsActionsMenu")).toBeDefined();
     expect(getByText("Actions")).toBeDefined();
   });
@@ -332,16 +316,15 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isViewer: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {queryByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     expect(queryByTestId("projectDetailsActionsMenu")).toBeNull();
     expect(queryByText("Actions")).toBeNull();
   });
   
   it("should render the 'Delete Project' action if the user has admin permissions", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     expect(getByText("Delete Project")).toBeDefined();
@@ -352,9 +335,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {queryByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     expect(queryByText("Delete Project")).toBeNull();
@@ -362,7 +344,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render the delete project modal when 'Delete Project' is clicked", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     const deleteItem = getByText("Delete Project");
@@ -375,9 +357,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     expect(getByText("Edit Project")).toBeDefined();
@@ -385,7 +366,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render the edit project modal when 'Edit Project' is clicked", async() => {
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     const editItem = getByText("Edit Project");
@@ -399,9 +380,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isAdmin: false, isManager: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     expect(getByText("Add Member")).toBeDefined();
@@ -412,9 +392,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isDeveloper: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     expect(getByText("New Story")).toBeDefined();
@@ -425,9 +404,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce(Object.assign({}, mockProjectResponse, {userRoles: {isDeveloper: true}}));
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, getByTestId, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     store.dispatch.mockReturnValueOnce({});
@@ -442,22 +420,21 @@ describe("<ProjectDetails />", () => {
   it("should render the add member modal when 'Add Member' is clicked", async() => {
     store.dispatch.mockReturnValueOnce({users: []});
     const {getByText, getByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const actionsMenu = getByTestId("projectDetailsActionsMenu");
     fireEvent.click(actionsMenu);
     const editItem = getByText("Add Member");
     fireEvent.click(editItem);
     expect(getByTestId("membershipModal.wrapper")).toBeDefined();
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(5));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
   });
 
   it("should render a message if there are no stories to display", async() => {
     store.dispatch = jest.fn().mockReturnValueOnce(mockProjectResponse);
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce({...mockStoriesResponse, stories: []});
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, queryByText} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const backlogTab = getByText("Backlog");
     expect(queryByText("This project has no stories")).toBeNull();
     fireEvent.click(backlogTab);
@@ -466,7 +443,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render a the stories table is the backlog tab is clicked", async() => {
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const backlogTab = getByText("Backlog");
     expect(queryByTestId("storiesTable")).toBeNull();
     fireEvent.click(backlogTab);
@@ -475,7 +452,7 @@ describe("<ProjectDetails />", () => {
 
   it("should show the delete story modal if the action is clicked with sufficient permission", async() => {
     const {getByText, getAllByTestId, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const backlogTab = getByText("Backlog");
     fireEvent.click(backlogTab);
     const deleteAction = getAllByTestId("action.deleteStory")[1];
@@ -489,9 +466,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce({...mockProjectResponse, userRoles: {}});
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     expect(queryByTestId("projectMembersSearch")).toBeNull();
     fireEvent.click(membersTab);
@@ -500,7 +476,7 @@ describe("<ProjectDetails />", () => {
 
   it("should render the members searchbar for project members", async() => {
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const membersTab = getByText("Members");
     expect(queryByTestId("projectMembersSearch")).toBeNull();
     fireEvent.click(membersTab);
@@ -512,9 +488,8 @@ describe("<ProjectDetails />", () => {
     store.dispatch.mockReturnValueOnce({...mockProjectResponse, userRoles: {}});
     store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
     store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce(mockPrioritiesResponse);
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const backlogTab = getByText("Backlog");
     expect(queryByTestId("projectStoriesSearch")).toBeNull();
     fireEvent.click(backlogTab);
@@ -523,86 +498,10 @@ describe("<ProjectDetails />", () => {
 
   it("should render the backlog searchbar for project members", async() => {
     const {getByText, queryByTestId} = render(<ProjectDetails {...props} />, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(3));
     const backlogTab = getByText("Backlog");
     expect(queryByTestId("projectStoriesSearch")).toBeNull();
     fireEvent.click(backlogTab);
     expect(queryByTestId("projectStoriesSearch")).toBeDefined();
-  });
-
-  it("should render a default message if there are no priorities", async() => {
-    const {getByText} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    expect(getByText("This project currently has no priorities.")).toBeDefined();
-  });
-
-  it("should render the prioritiesTable if there are priorities", async() => {
-    store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(mockProjectResponse);
-    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
-    store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce({
-      ...mockPrioritiesResponse,
-      priorities: [{
-        id: "testPriorityId1",
-        name: "Test Priority",
-        color: "#000000",
-        createdOn: "2020-08-01T23:27:34.147Z"
-      }]
-    });
-    const {getByText, getByTestId} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    expect(getByTestId("prioritiesTable")).toBeDefined();
-  });
-
-  it("should render the priority modal if 'Edit Priority' is clicked", async() => {
-    store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(mockProjectResponse);
-    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
-    store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce({
-      ...mockPrioritiesResponse,
-      priorities: [{
-        id: "testPriorityId1",
-        name: "Test Priority",
-        color: "#000000",
-        createdOn: "2020-08-01T23:27:34.147Z"
-      }]
-    });
-    const {getByText, getByTestId, queryByTestId} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    const editButton = getByTestId("action.editPriority");
-    expect(queryByTestId("priorityModal.wrapper")).toBeNull();
-    fireEvent.click(editButton);
-    expect(queryByTestId("priorityModal.wrapper")).toBeDefined();
-  });
-
-  it("should delete a priority if the delete action is clicked", async() => {
-    store.dispatch = jest.fn();
-    store.dispatch.mockReturnValueOnce(mockProjectResponse);
-    store.dispatch.mockReturnValueOnce(mockMembershipsResponse);
-    store.dispatch.mockReturnValueOnce(mockStoriesResponse);
-    store.dispatch.mockReturnValueOnce({
-      ...mockPrioritiesResponse,
-      priorities: [{
-        id: "testPriorityId1",
-        name: "Test Priority",
-        color: "#000000",
-        createdOn: "2020-08-01T23:27:34.147Z"
-      }]
-    });
-    const {getByText, getByTestId, queryByTestId} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    const deleteButton = getByTestId("action.deletePriority");
-    fireEvent.click(deleteButton);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(5));
   });
 });

--- a/src/containers/project-details/project-details.spec.jsx
+++ b/src/containers/project-details/project-details.spec.jsx
@@ -530,14 +530,6 @@ describe("<ProjectDetails />", () => {
     expect(queryByTestId("projectStoriesSearch")).toBeDefined();
   });
 
-  it("should render the priorities info message under the priorities tab", async() => {
-    const {getByText} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    expect(getByText("Priorities are project specific labels that can be attached to stories.")).toBeDefined();
-  });
-
   it("should render a default message if there are no priorities", async() => {
     const {getByText} = render(<ProjectDetails {...props}/>, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
@@ -565,25 +557,6 @@ describe("<ProjectDetails />", () => {
     const prioritiesTab = getByText("Priorities");
     fireEvent.click(prioritiesTab);
     expect(getByTestId("prioritiesTable")).toBeDefined();
-  });
-
-  it("should render the 'Add Priority' button", async() => {
-    const {getByText, getByTestId} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    expect(getByTestId("addPriorityButton")).toBeDefined();
-  });
-
-  it("should render the priority modal if 'Add Priority' is clicked", async() => {
-    const {getByText, getByTestId, queryByTestId} = render(<ProjectDetails {...props}/>, store);
-    await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(4));
-    const prioritiesTab = getByText("Priorities");
-    fireEvent.click(prioritiesTab);
-    const addButton = getByTestId("addPriorityButton");
-    expect(queryByTestId("priorityModal.wrapper")).toBeNull();
-    fireEvent.click(addButton);
-    expect(queryByTestId("priorityModal.wrapper")).toBeDefined();
   });
 
   it("should render the priority modal if 'Edit Priority' is clicked", async() => {

--- a/src/containers/sidebar/sidebar.jsx
+++ b/src/containers/sidebar/sidebar.jsx
@@ -38,8 +38,8 @@ const Sidebar = ({isOpen, location, historyPush}) => {
           <SidebarFooter data-testid="sidebarFooter">
             <FontAwesomeIcon icon={faGithub} size="2x" fixedWidth />
             <div>
-              <span><a href="https://github.com/zackdavis88/compass">UI</a></span>
-              <span><a href="https://github.com/zackdavis88/needle">API</a></span>
+              <span><a href="https://github.com/zackdavis88/compass" target="_blank">UI</a></span>
+              <span><a href="https://github.com/zackdavis88/needle" target="_blank">API</a></span>
             </div>
           </SidebarFooter>
         </SidebarContent>

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import NotFoundPage from "./containers/not-found-page/not-found-page";
 import Dashboard from "./containers/dashboard/dashboard";
 import ProjectDetails from "./containers/project-details/project-details";
 import StoryDetails from "./containers/story-details/story-details";
+import ProjectConfigs from "./containers/project-configs/project-configs";
 
 const routes = [
   {
@@ -23,6 +24,10 @@ const routes = [
     path: "/projects/:projectId/stories/:storyId",
     exact: true,
     component: StoryDetails
+  }, {
+    path: "/projects/:projectId/configs",
+    exact: true,
+    component: ProjectConfigs
   }, {
     path: "*",
     exact: false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,3 +106,15 @@ export const calcTextColor = (backgroundColor) => {
   else
     return "#FFFFFF";
 };
+
+export const updateQueryString = (key, value) => {
+  const newUrl = generateUrlWithQuery(key, value);
+  history.replaceState({path: newUrl}, "", newUrl);
+};
+
+export const onHeaderClick = (headerIndex) => {
+  if(headerIndex === 0)
+    return updateQueryString("activeTab", null);
+  
+  updateQueryString("activeTab", headerIndex);
+};


### PR DESCRIPTION
This PR contains:
- Renaming `DashboardProjectsTable` to `ProjectsTable`. Updated existing instances and unit tests.
- Updated `Sidebar` repository links to open in a new tab on click.
- Removed info message from `PrioritiesTable`. Removed unit tests around this functionality.
- Removed prioritiy functionality from `ProjectDetails`. Removed unit tests around this functionality.
- Added `updateQueryString` and `onHeaderClick` util methods. Removed duplicate instances of this code in various containers.
- Updated `Modal` and `TextArea` styling to work better with lower resolutions at 720p and up.
- Removed delete action from `ProjectsTable`.  Removed unit tests around this functionality.
- Added viewConfigs action to `ProjectsTable`. Added unit test.
- Added `Manage Configs` action-menu item on `ProjectDetails`. Added unit tests.
- Added `ProjectConfigs` container and route `/projects/:projectId/configs`. Added unit tests.
