### PR TITLE
Add transparent option

### DIFF
--- a/src/common-styles/base.js
+++ b/src/common-styles/base.js
@@ -44,10 +44,10 @@ export const PageError = styled.div`
   border-radius: 0;
 `;
 
-export const ProjectConfigLabel = styled.div.attrs(({color}) => ({
+export const ProjectConfigLabel = styled.div.attrs(({color, transparent}) => ({
   style: {
-    backgroundColor: color,
-    color: calcTextColor(color)
+    backgroundColor: transparent ? "#00000000" : color,
+    color: transparent ? "#000000" : calcTextColor(color)
   }
 }))`
   font-style: normal;

--- a/src/components/input-box/input-box.jsx
+++ b/src/components/input-box/input-box.jsx
@@ -12,7 +12,8 @@ const InputBox = (props) => {
     hasError: !!props.errorText,
     hasValue,
     helperText: props.errorText || props.helperText,
-    isColorPicker
+    isColorPicker,
+    id: `${props.id}-wrapper`
   };
 
   const inputProps = {

--- a/src/components/project-config-modal/project-config-modal.jsx
+++ b/src/components/project-config-modal/project-config-modal.jsx
@@ -4,6 +4,7 @@ import {ProjectConfigModalWrapper, ProjectSection, PreviewSection} from "./proje
 import Modal from "../modal/modal";
 import { faEdit, faPlus } from "@fortawesome/free-solid-svg-icons";
 import InputBox from "../input-box/input-box";
+import CheckBox from "../check-box/check-box";
 import {ProjectConfigLabel} from "../../common-styles/base";
 
 const ProjectConfigModal = (props) => {
@@ -12,6 +13,7 @@ const ProjectConfigModal = (props) => {
   const initialState = {
     name: isEdit ? projectConfig.name : "",
     color: isEdit && projectConfig.color ? projectConfig.color : "#FFFFFF",
+    transparent: isEdit ? !!projectConfig.transparent : false,
     nameError: undefined,
     colorError: undefined
   };
@@ -45,12 +47,12 @@ const ProjectConfigModal = (props) => {
   };
 
   const _onSubmit = async() => {
-    const {name, color} = state;
+    const {name, color, transparent} = state;
     let response;
     if(isEdit)
-      response = await props.onSubmit(props.project, projectConfig, name, color);
+      response = await props.onSubmit(props.project, projectConfig, name, color, transparent);
     else
-      response = await props.onSubmit(props.project, name, color);
+      response = await props.onSubmit(props.project, name, color, transparent);
 
     if(response.error && response.error.includes("name"))
       return setState({...state, nameError: response.error});
@@ -108,6 +110,15 @@ const ProjectConfigModal = (props) => {
       errorText: state.colorError,
       value: state.color,
       onChange: (value) => setState({...state, color: value, colorError: undefined})
+    },
+    transparent: {
+      id: "transparentInput",
+      dataTestId: "transparentInput",
+      label: "No Background Color",
+      checked: state.transparent,
+      onChange: () => {
+        setState({...state, transparent: !state.transparent});
+      }
     }
   };
 
@@ -121,11 +132,12 @@ const ProjectConfigModal = (props) => {
         <PreviewSection>
           <span>Preview:</span>
           {state.name ? (
-            <ProjectConfigLabel color={state.color}>{state.name}</ProjectConfigLabel>
+            <ProjectConfigLabel color={state.color} transparent={state.transparent}>{state.name}</ProjectConfigLabel>
           ): "Enter a name for preview"}
         </PreviewSection>
         <InputBox {...inputProps.name} />
         <InputBox {...inputProps.color} />
+        <CheckBox {...inputProps.transparent} />
       </Modal>
     </ProjectConfigModalWrapper>
   );

--- a/src/components/project-config-modal/project-config-modal.spec.jsx
+++ b/src/components/project-config-modal/project-config-modal.spec.jsx
@@ -76,14 +76,22 @@ describe("<ProjectConfigModal />", () => {
     const {queryByTestId} = render(<ProjectConfigModal {...props}/>);
     const nameInput = queryByTestId("nameInput");
     const colorInput = queryByTestId("colorInput");
+    const transparentInput = queryByTestId("transparentInput");
     expect(nameInput).toBeDefined();
     expect(colorInput).toBeDefined();
+    expect(transparentInput).toBeDefined();
   });
 
   it("should set the colorInput default value to #FFFFFF", () => {
-    const {queryByTestId} = render(<ProjectConfigModal {...props}/>);
-    const colorInput = queryByTestId("colorInput.input");
+    const {getByTestId} = render(<ProjectConfigModal {...props}/>);
+    const colorInput = getByTestId("colorInput.input");
     expect(colorInput).toHaveValue("#ffffff");
+  });
+
+  it("should default transparent input to false", () => {
+    const {getByTestId} = render(<ProjectConfigModal {...props}/>);
+    const transparentInput = getByTestId("transparentInput.input");
+    expect(transparentInput).not.toBeChecked();
   });
 
   it("should render preview text if there is name input", () => {
@@ -114,7 +122,7 @@ describe("<ProjectConfigModal />", () => {
       target: {value: "some name input"}
     });
     fireEvent.click(submitButton);
-    expect(props.onSubmit).toHaveBeenCalledWith(props.project, "some name input", "#FFFFFF");
+    expect(props.onSubmit).toHaveBeenCalledWith(props.project, "some name input", "#FFFFFF", false);
   });
 
   it("should set the nameError if there is a name validation error", async() => {
@@ -158,7 +166,7 @@ describe("<ProjectConfigModal />", () => {
       target: {value: "#a82c9b"}
     });
     fireEvent.click(submitButton);
-    expect(props.onSubmit).toHaveBeenCalledWith(props.project, "Test Priority", "#a82c9b");
+    expect(props.onSubmit).toHaveBeenCalledWith(props.project, "Test Priority", "#a82c9b", false);
     await waitFor(() => expect(props.onClose).toHaveBeenCalled());
   });
 
@@ -245,6 +253,18 @@ describe("<ProjectConfigModal />", () => {
     expect(colorInput).toHaveValue(props.projectConfig.color);
   });
 
+  it("should set the transparent input value based on the priority being updated", () => {
+    props.projectConfig = {
+      id: "testPriorityId1",
+      name: "unit test priority",
+      color: "#0194cc",
+      transparent: true
+    };
+    const {getByTestId} = render(<ProjectConfigModal {...props}/>);
+    const transparentInput = getByTestId("transparentInput.input");
+    expect(transparentInput).toBeChecked();
+  });
+
   it("should call the onSubmit method if submit is clicked when updating", async() => {
     props.projectConfig = {
       id: "testPriorityId1",
@@ -260,7 +280,7 @@ describe("<ProjectConfigModal />", () => {
     fireEvent.change(colorInput, {target: { value: colorVal}});
     const submitButton = getByTestId("projectConfigModal.actions.primaryButton");
     fireEvent.click(submitButton);
-    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledWith(props.project, props.projectConfig, nameVal, colorVal));
+    await waitFor(() => expect(props.onSubmit).toHaveBeenCalledWith(props.project, props.projectConfig, nameVal, colorVal, false));
   });
 
 

--- a/src/components/project-config-modal/project-config-modal.styles.js
+++ b/src/components/project-config-modal/project-config-modal.styles.js
@@ -4,8 +4,18 @@ import {ProjectConfigLabel} from "../../common-styles/base";
 export const ProjectConfigModalWrapper = styled.div`
   position: relative;
 
+  & #colorInput-wrapper {
+    display: inline-block;
+  }
+
   & #colorInput {
     width: 75px;
+  }
+
+  & #transparentInput {
+    display: inline-block;
+    top: -5px;
+    margin-left: 25px;
   }
 `;
 

--- a/src/components/project-configs-table/project-configs-table.jsx
+++ b/src/components/project-configs-table/project-configs-table.jsx
@@ -57,7 +57,7 @@ const ProjectConfigsTable = ({projectConfigs, configType, userRoles, actions, pa
     headers: [{
       label: configName,
       keyName: "name",
-      format: (name, {color}) => <ProjectConfigLabel color={color}>{name}</ProjectConfigLabel>
+      format: (name, {color, transparent}) => <ProjectConfigLabel color={color} transparent={transparent}>{name}</ProjectConfigLabel>
     }, {
       label: "Unique ID",
       keyName: "id"

--- a/src/components/stories-table/stories-table.jsx
+++ b/src/components/stories-table/stories-table.jsx
@@ -62,7 +62,7 @@ const StoriesTable = ({stories, project, actions, pagination}) => {
       keyName: "priority",
       format: (priority) => {
         if(priority)
-          return <ProjectConfigLabel color={priority.color}>{priority.name}</ProjectConfigLabel>
+          return <ProjectConfigLabel color={priority.color} transparent={priority.transparent}>{priority.name}</ProjectConfigLabel>
         
         return  <div style={{fontStyle: "italic"}}>No Priority</div>
       }

--- a/src/containers/story-details/story-details.jsx
+++ b/src/containers/story-details/story-details.jsx
@@ -126,7 +126,7 @@ const StoryDetails = (props) => {
                       <SideItem>
                         <span>Priority</span>
                         {story.priority ? (
-                          <ProjectConfigLabel color={story.priority.color}>{story.priority.name}</ProjectConfigLabel>
+                          <ProjectConfigLabel color={story.priority.color} transparent={story.priority.transparent}>{story.priority.name}</ProjectConfigLabel>
                         ) : (
                           <div style={{fontStyle: "italic"}}>None</div>
                         )}

--- a/src/store/actions/priority.js
+++ b/src/store/actions/priority.js
@@ -5,23 +5,26 @@ import {
   PRIORITY_REQUEST_FAILURE
 } from "../types/priority";
 
-export const createPriority = (project, name, color) => dispatch => {
+export const createPriority = (project, name, color, transparent) => dispatch => {
   return dispatch({
     types: [PRIORITY_REQUEST_START, PRIORITY_REQUEST_SUCCESS, PRIORITY_REQUEST_FAILURE],
     request: request.post(`/api/projects/${project.id}/priorities`),
     payload: {
       name,
-      color
+      color,
+      transparent
     }
   });
 };
 
-export const updatePriority = (project, priority, name, color) => dispatch => {
+export const updatePriority = (project, priority, name, color, transparent) => dispatch => {
   const payload = {};
   if(name)
     payload.name = name;
   if(color)
     payload.color = color;
+  if(typeof transparent === "boolean")
+    payload.transparent = transparent;
   return dispatch({
     types: [PRIORITY_REQUEST_START, PRIORITY_REQUEST_SUCCESS, PRIORITY_REQUEST_FAILURE],
     request: request.post(`/api/projects/${project.id}/priorities/${priority.id}`),

--- a/src/store/actions/status.js
+++ b/src/store/actions/status.js
@@ -5,23 +5,26 @@ import {
   STATUS_REQUEST_FAILURE
 } from "../types/status";
 
-export const createStatus = (project, name, color) => dispatch => {
+export const createStatus = (project, name, color, transparent) => dispatch => {
   return dispatch({
     types: [STATUS_REQUEST_START, STATUS_REQUEST_SUCCESS, STATUS_REQUEST_FAILURE],
     request: request.post(`/api/projects/${project.id}/status`),
     payload: {
       name,
-      color
+      color,
+      transparent
     }
   });
 };
 
-export const updateStatus = (project, status, name, color) => dispatch => {
+export const updateStatus = (project, status, name, color, transparent) => dispatch => {
   const payload = {};
   if(name)
     payload.name = name;
   if(color)
     payload.color = color;
+  if(typeof transparent === "boolean")
+    payload.transparent = transparent;
   return dispatch({
     types: [STATUS_REQUEST_START, STATUS_REQUEST_SUCCESS, STATUS_REQUEST_FAILURE],
     request: request.post(`/api/projects/${project.id}/status/${status.id}`),


### PR DESCRIPTION
This PR contains:
- Update to `InputBox` to include an `id` for the wrapper.
- Update to `ProjectConfigLabel` to support a `transparent` property.
- Update to all instances of ProjectConfigLabel across components to add the `transparent` prop.
- Added `transparent` prop support to `ProjectConfigsModal` with a new input. Added unit tests.
- Updated `priority` and `status` redux actions to support `transparent` prop.