### PR TITLE
Add CollapsiblePanel and ProjectCollapsibleList

### DIFF
--- a/src/common-styles/animations.js
+++ b/src/common-styles/animations.js
@@ -41,3 +41,12 @@ export const fullRotate = keyframes`
     transform: rotate(360deg);
   }
 `;
+
+export const rotate180 = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(180deg);
+  }
+`;

--- a/src/common-styles/variables.js
+++ b/src/common-styles/variables.js
@@ -25,6 +25,7 @@ export const secondaryBlue = "#185B8A";
 export const secondaryBlue1a = "#185B8A1A";
 export const tertiaryBlue = "#114E79";
 export const tertiaryBlue26 = "#114E7926";
+export const tertiaryBlue50 = "#114E7950";
 
 export const primaryRed = "#DC3545";
 export const secondaryRed = "#C43240";

--- a/src/components/collapsible-panel/collapsible-panel.jsx
+++ b/src/components/collapsible-panel/collapsible-panel.jsx
@@ -3,21 +3,62 @@ import PropTypes from "prop-types";
 import {
   CollapsiblePanelWrapper,
   PanelHeader,
-  PanelContent
+  PanelContent,
+  Action,
+  ActionsWrapper
 } from "./collapsible-panel.styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {faPlus, faMinus} from "@fortawesome/free-solid-svg-icons";
+import {faChevronUp} from "@fortawesome/free-solid-svg-icons";
 
 const CollapsiblePanel = (props) => {
   const contentElement = useRef(null);
   const contentHeight = contentElement.current && contentElement.current.scrollHeight;
+  const expandCollapseAction = useRef(null);
+
+  const _onClick = () => {
+    const classList = expandCollapseAction.current.classList;
+    const newValue = !props.isActive;
+    props.onHeaderClick(newValue);
+    // We got set to active. Remove the rotateUp class and attach rotateDown.
+    if(newValue) {
+      classList.remove("rotateUp");
+      void expandCollapseAction.current.offsetWidth; // REQUIRED black-magic to get the animations to retrigger every click.
+      classList.add("rotateDown");
+    }
+    else {
+      classList.remove("rotateDown");
+      void expandCollapseAction.current.offsetWidth;
+      classList.add("rotateUp");
+    }
+  };
+
+  const wrapperProps = {isActive: props.isActive, contentHeight};
+  const headerProps = {type: "button", onClick: _onClick};
+  const contentProps = {ref: contentElement};
+  const expandCollapseProps = {ref: expandCollapseAction, className: "collapsibleExpandAction highlightAction"};
+  const actionsProps = {};
+  if(props.dataTestId) {
+    wrapperProps["data-testid"] = props.dataTestId;
+    headerProps["data-testid"] = `${props.dataTestId}.header`;
+    contentProps["data-testid"] = `${props.dataTestId}.contentPanel`;
+    expandCollapseProps["data-testid"] = `${props.dataTestId}.toggleAction`;
+    actionsProps["data-testid"] = `${props.dataTestId}.actionsWrapper`;
+  }
+
   return (
-    <CollapsiblePanelWrapper isActive={props.isActive} contentHeight={contentHeight}>
-      <PanelHeader type="button" onClick={() => props.onHeaderClick(!props.isActive)}>
-        {props.headerText}
-        <FontAwesomeIcon icon={props.isActive ? faMinus : faPlus} fixedWidth />
+    <CollapsiblePanelWrapper {...wrapperProps}>
+      <PanelHeader {...headerProps}>
+        <div>{props.headerText}</div>
+        <Action {...expandCollapseProps}>
+          <FontAwesomeIcon icon={faChevronUp} fixedWidth />
+        </Action>
+        {props.actions && (
+          <ActionsWrapper {...actionsProps}>
+            {props.actions}
+          </ActionsWrapper>
+        )}
       </PanelHeader>
-      <PanelContent ref={contentElement}>
+      <PanelContent {...contentProps}>
         {props.children}
       </PanelContent>
     </CollapsiblePanelWrapper>
@@ -27,7 +68,9 @@ const CollapsiblePanel = (props) => {
 CollapsiblePanel.propTypes = {
   isActive: PropTypes.bool.isRequired,
   onHeaderClick: PropTypes.func.isRequired,
-  headerText: PropTypes.string.isRequired
+  headerText: PropTypes.string.isRequired,
+  actions: PropTypes.element,
+  dataTestId: PropTypes.string
 };
 
 export default CollapsiblePanel;

--- a/src/components/collapsible-panel/collapsible-panel.jsx
+++ b/src/components/collapsible-panel/collapsible-panel.jsx
@@ -1,0 +1,33 @@
+import React, {useRef} from "react";
+import PropTypes from "prop-types";
+import {
+  CollapsiblePanelWrapper,
+  PanelHeader,
+  PanelContent
+} from "./collapsible-panel.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faPlus, faMinus} from "@fortawesome/free-solid-svg-icons";
+
+const CollapsiblePanel = (props) => {
+  const contentElement = useRef(null);
+  const contentHeight = contentElement.current && contentElement.current.scrollHeight;
+  return (
+    <CollapsiblePanelWrapper isActive={props.isActive} contentHeight={contentHeight}>
+      <PanelHeader type="button" onClick={() => props.onHeaderClick(!props.isActive)}>
+        {props.headerText}
+        <FontAwesomeIcon icon={props.isActive ? faMinus : faPlus} fixedWidth />
+      </PanelHeader>
+      <PanelContent ref={contentElement}>
+        {props.children}
+      </PanelContent>
+    </CollapsiblePanelWrapper>
+  );
+};
+
+CollapsiblePanel.propTypes = {
+  isActive: PropTypes.bool.isRequired,
+  onHeaderClick: PropTypes.func.isRequired,
+  headerText: PropTypes.string.isRequired
+};
+
+export default CollapsiblePanel;

--- a/src/components/collapsible-panel/collapsible-panel.spec.jsx
+++ b/src/components/collapsible-panel/collapsible-panel.spec.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import CollapsiblePanel from "./collapsible-panel";
+import {Action} from "./collapsible-panel.styles";
+import { render } from "../../test-utils";
+import {fireEvent} from "@testing-library/react";
+
+describe("<CollapsiblePanel />", () => {
+  let props;
+  let component;
+  beforeEach(() => {
+    props = {
+      dataTestId: "unitTestCollapsiblePanel",
+      isActive: false,
+      onHeaderClick: jest.fn(),
+      headerText: "Unit Testing Collapsible Panel"
+    };
+    component = (
+      <CollapsiblePanel {...props} >
+        unit test sample text
+      </CollapsiblePanel>
+    );
+  });
+
+  it("should mount the component", () => {
+    expect(render(component)).toBeDefined();
+  });
+
+  it("should render the panel header and header text", () => {
+    const {getByTestId, getByText} = render(component);
+    expect(getByTestId("unitTestCollapsiblePanel")).toBeDefined();
+    expect(getByTestId("unitTestCollapsiblePanel.header")).toBeDefined();
+    expect(getByText("Unit Testing Collapsible Panel")).toBeDefined();
+  });
+
+  it("should render the panel content as hidden by default", () => {
+    const {getByTestId} = render(component);
+    const contentPanel = getByTestId("unitTestCollapsiblePanel.contentPanel")
+    expect(contentPanel).toBeDefined();
+    const contentPanelStyles = window.getComputedStyle(contentPanel);
+    expect(contentPanelStyles.maxHeight).toEqual("0");
+  });
+
+  it("should render the panel content when isActive is true", () => {
+    props = {...props, isActive: true};
+    component = <CollapsiblePanel {...props}><div>sample content text</div></CollapsiblePanel>;
+    const {getByText} = render(component);
+    expect(getByText("sample content text")).toBeDefined();
+  });
+
+  it("should call props.onHeaderClick when the header is clicked", () => {
+    const {getByTestId} = render(component);
+    const panelHeader = getByTestId(`${props.dataTestId}.header`);
+    fireEvent.click(panelHeader);
+    expect(props.onHeaderClick).toHaveBeenCalledWith(!props.isActive);
+    fireEvent.click(panelHeader);
+    expect(props.onHeaderClick).toHaveBeenLastCalledWith(!props.isActive);
+    expect(props.onHeaderClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("should render the expand/collapse Action component", () => {
+    const {getByTestId} = render(component);
+    expect(getByTestId(`${props.dataTestId}.toggleAction`)).toBeDefined();
+  });
+
+  it("should set the rotateDown class when an in-active header is clicked", () => {
+    const {getByTestId} = render(component);
+    const expandCollapseAction = getByTestId(`${props.dataTestId}.toggleAction`);
+    expect(expandCollapseAction.className).not.toContain("rotateDown");
+    fireEvent.click(expandCollapseAction);
+    expect(expandCollapseAction.className).toContain("rotateDown");
+  });
+
+  it("should set the rotateUp class when an active header is clicked", () => {
+    props = {...props, isActive: true};
+    component = <CollapsiblePanel {...props}><div>sample content text</div></CollapsiblePanel>;
+    const {getByTestId} = render(component);
+    const expandCollapseAction = getByTestId(`${props.dataTestId}.toggleAction`);
+    expect(expandCollapseAction.className).not.toContain("rotateUp");
+    fireEvent.click(expandCollapseAction);
+    expect(expandCollapseAction.className).toContain("rotateUp");
+  });
+
+  it("should not render the ActionsWrapper if props.actions is not present", () => {
+    const {queryByTestId} = render(component);
+    expect(queryByTestId(`${props.dataTestId}.actionsWrapper`)).toBeNull();
+  });
+
+  it("should render the ActionsWrapper if props.actions is present", () => {
+    props.actions = <Action>test action</Action>;
+    component = <CollapsiblePanel {...props}>sample content</CollapsiblePanel>;
+    const {queryByTestId, getByText} = render(component);
+    expect(queryByTestId(`${props.dataTestId}.actionsWrapper`)).toBeDefined();
+    expect(getByText("test action")).toBeDefined();
+  });
+});

--- a/src/components/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/collapsible-panel/collapsible-panel.styles.js
@@ -1,12 +1,61 @@
 import styled, {css} from "styled-components";
 import {
   transparent, 
-  black, 
+  black,
+  black33,
   black80,
   tertiaryBlue26,
   tertiaryBlue50,
   secondaryBlue1a
 } from "../../common-styles/variables";
+import {TooltipWrapper} from "../tooltip/tooltip.styles";
+import {rotate180} from "../../common-styles/animations";
+
+export const Action = styled.div`
+  position: relative;
+  user-select: none;
+  line-height: 0;
+  cursor: not-allowed;
+  color: ${black33};
+  transition: color 100ms linear;
+
+  &:hover ${TooltipWrapper} {
+    font-size: 16px;
+    visibility: visible;
+    opacity: 1;
+    left: -50px;
+    bottom: -33px;
+    padding: 5px;
+  }
+`;
+
+export const LinkAction = styled.a`
+  text-decoration: none;
+  position: relative;
+  user-select: none;
+  line-height: 0;
+  cursor: not-allowed;
+  color: ${black33};
+  transition: color 100ms linear;
+
+  &:hover ${TooltipWrapper} {
+    font-size: 16px;
+    visibility: visible;
+    opacity: 1;
+    left: -50px;
+    bottom: -33px;
+    padding: 5px;
+  }
+`;
+
+export const ActionsWrapper = styled.div`
+  float: right;
+  margin-right: 15px;
+  ${Action}, ${LinkAction} {
+    display: inline-block;
+    margin-left: 5px;
+  }
+`;
 
 export const PanelHeader = styled.button`
   background-color: ${secondaryBlue1a};
@@ -23,9 +72,32 @@ export const PanelHeader = styled.button`
   &:hover {
     background-color: ${tertiaryBlue26};
   }
-
-  & > svg {
+  & > div:first-of-type {
+    display: inline-block;
+    max-width: 85%;
+    padding-right: 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  & > .collapsibleExpandAction {
     float: right;
+  }
+  &:hover ${Action}.highlightAction {
+    color: ${black};
+    cursor: pointer;
+  }
+  &:hover ${LinkAction}.highlightAction {
+    color: ${black};
+    cursor: pointer;
+  }
+
+  & .collapsibleExpandAction.rotateDown {
+    animation: ${rotate180} 175ms linear 0s 1;
+    animation-fill-mode: forwards;
+  }
+  & .collapsibleExpandAction.rotateUp {
+    animation: ${rotate180} 175ms linear 0s 1;
+    animation-direction: reverse;
   }
 `;
 
@@ -37,7 +109,7 @@ export const PanelContent = styled.div`
   padding: 0;
   border: 1px solid ${transparent};
   border-radius: 0 0 5px 5px;
-  transition: max-height 100ms linear, border-color 100ms linear;
+  transition: max-height 150ms linear, border-color 100ms linear;
 `;
 
 export const CollapsiblePanelWrapper = styled.div`
@@ -49,6 +121,10 @@ export const CollapsiblePanelWrapper = styled.div`
     & ${PanelHeader} {
       background-color: ${tertiaryBlue50};
       border-radius: 5px 5px 0 0;
+    }
+
+    & ${PanelHeader} > ${Action}.highlightAction {
+      color: ${black};
     }
   `}
 

--- a/src/components/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/collapsible-panel/collapsible-panel.styles.js
@@ -126,6 +126,14 @@ export const CollapsiblePanelWrapper = styled.div`
     & ${PanelHeader} > ${Action}.highlightAction {
       color: ${black};
     }
+
+    & ${PanelHeader} > ${ActionsWrapper} > ${Action}.highlightAction {
+      color: ${black};
+    }
+
+    & ${PanelHeader} > ${ActionsWrapper} > ${LinkAction}.highlightAction {
+      color: ${black};
+    }
   `}
 
   ${({isActive, contentHeight}) => isActive && contentHeight && css`

--- a/src/components/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/collapsible-panel/collapsible-panel.styles.js
@@ -1,0 +1,63 @@
+import styled, {css} from "styled-components";
+import {
+  transparent, 
+  black, 
+  black80,
+  tertiaryBlue26,
+  tertiaryBlue50,
+  secondaryBlue1a
+} from "../../common-styles/variables";
+
+export const PanelHeader = styled.button`
+  background-color: ${secondaryBlue1a};
+  color: ${black};
+  cursor: pointer;
+  padding: 20px;
+  width: 100%;
+  border: 1px solid ${black80};
+  text-align: left;
+  outline: none;
+  font-size: 18px;
+  border-radius: 5px;
+  transition: border-radius 100ms linear, border-color 100ms linear, background-color 100ms linear;
+  &:hover {
+    background-color: ${tertiaryBlue26};
+  }
+
+  & > svg {
+    float: right;
+  }
+`;
+
+export const PanelContent = styled.div`
+  overflow: hidden;
+  background-color: #f1f1f1;
+  max-height: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid ${transparent};
+  border-radius: 0 0 5px 5px;
+  transition: max-height 100ms linear, border-color 100ms linear;
+`;
+
+export const CollapsiblePanelWrapper = styled.div`
+  position: relative;
+  display: block;
+  user-select: text;
+
+  ${({isActive}) => isActive && css`
+    & ${PanelHeader} {
+      background-color: ${tertiaryBlue50};
+      border-radius: 5px 5px 0 0;
+    }
+  `}
+
+  ${({isActive, contentHeight}) => isActive && contentHeight && css`
+    & ${PanelContent} {
+      max-height: ${contentHeight}px;
+      border-left: 1px solid ${black80};
+      border-right: 1px solid ${black80};
+      border-bottom: 1px solid ${black80};
+    }
+  `}
+`;

--- a/src/components/project-collapsible-list/project-collapsible-list.jsx
+++ b/src/components/project-collapsible-list/project-collapsible-list.jsx
@@ -1,0 +1,68 @@
+import React, {useState, useEffect} from "react";
+import PropTypes from "prop-types";
+import {ProjectCollapsibleListWrapper} from "./project-collapsible-list.styles";
+import CollapsiblePanel from "../collapsible-panel/collapsible-panel";
+import {getPermissionLevel, formatDate} from "../../utils";
+import Pagination from "../pagination/pagination";
+
+const ProjectCollapsibleList = ({projects, pagination}) => {
+  const [activeMap, setActiveMap] = useState({});
+  useEffect(() => {
+    const newActiveMap = projects.reduce((prev, project) => {
+      if(!prev[project.id])
+        return Object.assign(prev, {[project.id]: false});
+      return prev;
+    }, {});
+    setActiveMap(newActiveMap);
+  }, [projects]);
+
+  const _generateContent = (project) => (
+    <div>
+      <div className="dataLabel"><span>Unique ID:</span> {project.id}</div>
+      <div className="dataLabel"><span>Permission Level:</span> {getPermissionLevel(project.roles)}</div>
+      <div className="dataLabel"><span>Created On:</span> {formatDate(project.createdOn)}</div>
+      <div className="dataLabel"><span>Visibility:</span> {project.isPrivate ? "Private" : "Public"}</div>
+      {project.updatedOn && (
+        <div className="dataLabel"><span>Last Modified:</span> {formatDate(project.updatedOn)}</div>
+      )}
+    </div>
+  );
+  const {itemsPerPage, totalPages, page, getPage} = pagination;
+
+  return (
+    <ProjectCollapsibleListWrapper>
+      {projects && projects.map((project, index) => (
+        <CollapsiblePanel
+          key={index} 
+          isActive={activeMap[project.id] || false} 
+          onHeaderClick={(value) => setActiveMap({...activeMap, [project.id]: value})}
+          headerText={project.name}
+        >
+          {_generateContent(project)}
+        </CollapsiblePanel>
+      ))}
+      {totalPages > 1 && (
+        <div className="paginationSection">
+          <Pagination 
+            itemsPerPage={itemsPerPage} 
+            page={page} 
+            totalPages={totalPages} 
+            onPageClick={(page) => getPage(page)}
+          />
+        </div>
+      )}
+    </ProjectCollapsibleListWrapper>
+  );
+};
+
+ProjectCollapsibleList.propTypes = {
+  projects: PropTypes.array.isRequired,
+  pagination: PropTypes.shape({
+    page: PropTypes.number.isRequired,
+    totalPages: PropTypes.number.isRequired,
+    itemsPerPage: PropTypes.number.isRequired,
+    getPage: PropTypes.func.isRequired
+  }).isRequired
+};
+
+export default ProjectCollapsibleList;

--- a/src/components/project-collapsible-list/project-collapsible-list.jsx
+++ b/src/components/project-collapsible-list/project-collapsible-list.jsx
@@ -1,11 +1,15 @@
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, Fragment} from "react";
 import PropTypes from "prop-types";
 import {ProjectCollapsibleListWrapper} from "./project-collapsible-list.styles";
 import CollapsiblePanel from "../collapsible-panel/collapsible-panel";
+import {Action, LinkAction} from "../collapsible-panel/collapsible-panel.styles";
 import {getPermissionLevel, formatDate} from "../../utils";
 import Pagination from "../pagination/pagination";
+import {faUserPlus, faBook, faArrowRight, faWrench} from "@fortawesome/free-solid-svg-icons";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import Tooltip from "../tooltip/tooltip";
 
-const ProjectCollapsibleList = ({projects, pagination}) => {
+const ProjectCollapsibleList = ({projects, actions, pagination, dataTestId}) => {
   const [activeMap, setActiveMap] = useState({});
   useEffect(() => {
     const newActiveMap = projects.reduce((prev, project) => {
@@ -27,20 +31,61 @@ const ProjectCollapsibleList = ({projects, pagination}) => {
       )}
     </div>
   );
+
   const {itemsPerPage, totalPages, page, getPage} = pagination;
+  const _renderActions = (project) => {
+    const {addStory, addMember, viewConfigs, viewDetails} = actions;
+    const {isAdmin, isManager, isDeveloper, isViewer} = project.roles;
+    const adminAllowed = isAdmin;
+    const managerAllowed = (isAdmin || isManager);
+    const developerAllowed = (isAdmin || isManager || isDeveloper);
+    const viewerAllowed = (isAdmin || isManager || isDeveloper || isViewer);
+    return (
+      <Fragment>
+        <Action data-testid="action.addMember" className={managerAllowed ? "highlightAction" : ""} onClick={(e) => {e.stopPropagation();if(managerAllowed) return addMember(project, adminAllowed)}}>
+          <FontAwesomeIcon icon={faUserPlus} fixedWidth />
+          {managerAllowed && <Tooltip text={"Add Member"} />}
+        </Action>
+        <Action data-testid="action.addStory" className={developerAllowed ? "highlightAction" : ""} onClick={(e) => {e.stopPropagation();if(developerAllowed) return addStory(project)}}>
+          <FontAwesomeIcon icon={faBook} fixedWidth />
+          {developerAllowed && <Tooltip text={"Add Story"} />}
+        </Action>
+        <LinkAction
+        data-testid="action.viewProjectConfigs" 
+        className={viewerAllowed ? "highlightAction" : ""}
+        href={`/projects/${project.id}/configs`} 
+        onClick={(e) => {e.preventDefault();e.stopPropagation();if(viewerAllowed) return viewConfigs(project)}}>
+          <FontAwesomeIcon icon={faWrench} fixedWidth />
+          {viewerAllowed && <Tooltip text={"Manage Configs"} />}
+        </LinkAction>
+        <LinkAction
+        data-testid="action.viewProject" 
+        className={viewerAllowed ? "highlightAction" : ""}
+        href={`/projects/${project.id}`} 
+        onClick={(e) => {e.preventDefault();e.stopPropagation();if(viewerAllowed) return viewDetails(project)}}>
+          <FontAwesomeIcon icon={faArrowRight} fixedWidth />
+          {viewerAllowed && <Tooltip text={"View Project"} />}
+        </LinkAction>
+      </Fragment>
+    )
+  };
 
   return (
     <ProjectCollapsibleListWrapper>
-      {projects && projects.map((project, index) => (
+      {projects && projects.length ? projects.map((project, index) => (
         <CollapsiblePanel
           key={index} 
           isActive={activeMap[project.id] || false} 
           onHeaderClick={(value) => setActiveMap({...activeMap, [project.id]: value})}
           headerText={project.name}
+          actions={_renderActions(project)}
+          dataTestId={dataTestId ? `${dataTestId}.collapsible.${index}` : ""}
         >
           {_generateContent(project)}
         </CollapsiblePanel>
-      ))}
+      )) : (
+        <div>There are no projects to display</div>
+      )}
       {totalPages > 1 && (
         <div className="paginationSection">
           <Pagination 
@@ -48,6 +93,7 @@ const ProjectCollapsibleList = ({projects, pagination}) => {
             page={page} 
             totalPages={totalPages} 
             onPageClick={(page) => getPage(page)}
+            dataTestId="projectsPagination"
           />
         </div>
       )}
@@ -57,12 +103,19 @@ const ProjectCollapsibleList = ({projects, pagination}) => {
 
 ProjectCollapsibleList.propTypes = {
   projects: PropTypes.array.isRequired,
+  actions: PropTypes.shape({
+    addMember: PropTypes.func.isRequired,
+    addStory: PropTypes.func.isRequired,
+    viewDetails: PropTypes.func.isRequired,
+    viewConfigs: PropTypes.func.isRequired
+  }).isRequired,
   pagination: PropTypes.shape({
     page: PropTypes.number.isRequired,
     totalPages: PropTypes.number.isRequired,
     itemsPerPage: PropTypes.number.isRequired,
     getPage: PropTypes.func.isRequired
-  }).isRequired
+  }).isRequired,
+  dataTestId: PropTypes.string
 };
 
 export default ProjectCollapsibleList;

--- a/src/components/project-collapsible-list/project-collapsible-list.jsx
+++ b/src/components/project-collapsible-list/project-collapsible-list.jsx
@@ -69,9 +69,10 @@ const ProjectCollapsibleList = ({projects, actions, pagination, dataTestId}) => 
       </Fragment>
     )
   };
+  const wrapperProps = dataTestId ? {"data-testid": dataTestId} : {};
 
   return (
-    <ProjectCollapsibleListWrapper>
+    <ProjectCollapsibleListWrapper {...wrapperProps}>
       {projects && projects.length ? projects.map((project, index) => (
         <CollapsiblePanel
           key={index} 

--- a/src/components/project-collapsible-list/project-collapsible-list.spec.jsx
+++ b/src/components/project-collapsible-list/project-collapsible-list.spec.jsx
@@ -1,0 +1,161 @@
+import React from "react";
+import ProjectCollapsibleList from "./project-collapsible-list";
+import { render } from "../../test-utils";
+import {fireEvent} from "@testing-library/react";
+
+describe("<ProjectCollapsibleList />", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      projects: [{
+        id: "testProject1",
+        name: "Some Name",
+        isPrivate: true,
+        createdOn: "2020-08-01T19:08:37.237Z",
+        roles: {
+          isAdmin: true
+        }
+      }, {
+        id: "testProject2",
+        name: "Another Name",
+        isPrivate: false,
+        createdOn: "2020-08-05T12:00:37.237Z",
+        updatedOn: "2020-08-07T12:00:37.237Z",
+        roles: {
+          isDeveloper: true
+        }
+      }],
+      actions: {
+        addMember:jest.fn(),
+        addStory:jest.fn(),
+        viewDetails:jest.fn(),
+        viewConfigs:jest.fn()
+      },
+      pagination: {
+        page: 1,
+        totalPages: 5,
+        itemsPerPage: 10,
+        getPage: jest.fn()
+      },
+      dataTestId: "unitTestProjectList"
+    };
+  });
+
+  it("should mount the component", () => {
+    const component = render(<ProjectCollapsibleList {...props} />);
+    expect(component).toBeDefined();
+  });
+
+  it("should render a default message is there are no projects", () => {
+    props.projects = [];
+    const {getByText} = render(<ProjectCollapsibleList {...props} />);
+    expect(getByText("There are no projects to display")).toBeDefined();
+  });
+
+  it("should render a collapsible panel for each project", () => {
+    const {getByTestId} = render(<ProjectCollapsibleList {...props} />);
+    expect(getByTestId(`${props.dataTestId}.collapsible.0`)).toBeDefined();
+    expect(getByTestId(`${props.dataTestId}.collapsible.1`)).toBeDefined();
+  });
+
+  it("should render the data for each project", () => {
+    const {getByText} = render(<ProjectCollapsibleList {...props} />);
+    expect(getByText("testProject1")).toBeDefined();
+    expect(getByText("Some Name")).toBeDefined();
+    expect(getByText("Private")).toBeDefined();
+    expect(getByText("Admin")).toBeDefined();
+    expect(getByText("Aug 1, 2020")).toBeDefined();
+
+    expect(getByText("testProject2")).toBeDefined();
+    expect(getByText("Another Name")).toBeDefined();
+    expect(getByText("Public")).toBeDefined();
+    expect(getByText("Developer")).toBeDefined();
+    expect(getByText("Aug 5, 2020")).toBeDefined();
+    expect(getByText("Aug 7, 2020")).toBeDefined();
+  });
+
+  it("should render the expected projects actions", () => {
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    expect(getAllByTestId("action.addMember")).toHaveLength(2);
+    expect(getAllByTestId("action.addStory")).toHaveLength(2);
+    expect(getAllByTestId("action.viewProjectConfigs")).toHaveLength(2);
+    expect(getAllByTestId("action.viewProject")).toHaveLength(2);
+  });
+
+  it("should call actions.addMember when the add member action is clicked with permissions", () => {
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const addMemberAction = getAllByTestId("action.addMember")[0];
+    fireEvent.click(addMemberAction);
+    expect(props.actions.addMember).toHaveBeenCalledWith(props.projects[0], true);
+  });
+
+  it("should call actions.addStory when the add story action is clicked with permissions", () => {
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const addStoryAction = getAllByTestId("action.addStory")[0];
+    fireEvent.click(addStoryAction);
+    expect(props.actions.addStory).toHaveBeenCalledWith(props.projects[0]);
+  });
+
+  it("should call actions.viewConfigs when the view configs action is clicked with permissions", () => {
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const viewConfigsAction = getAllByTestId("action.viewProjectConfigs")[0];
+    fireEvent.click(viewConfigsAction);
+    expect(props.actions.viewConfigs).toHaveBeenCalledWith(props.projects[0]);
+  });
+
+  it("should call actions.viewProject when the view project action is clicked with permissions", () => {
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const viewProjectAction = getAllByTestId("action.viewProject")[0];
+    fireEvent.click(viewProjectAction);
+    expect(props.actions.viewDetails).toHaveBeenCalledWith(props.projects[0]);
+  });
+
+  it("should not call actions.addMember if clicked with insufficient permission", () => {
+    props.projects[0].roles = {};
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const addMemberAction = getAllByTestId("action.addMember")[0];
+    fireEvent.click(addMemberAction);
+    expect(props.actions.addMember).not.toHaveBeenCalled();
+  });
+
+  it("should not call actions.addStory if clicked with insufficient permission", () => {
+    props.projects[0].roles = {};
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const addStoryAction = getAllByTestId("action.addStory")[0];
+    fireEvent.click(addStoryAction);
+    expect(props.actions.addStory).not.toHaveBeenCalled();
+  });
+
+  it("should not call actions.viewConfigs if clicked with insufficient permission", () => {
+    props.projects[0].roles = {};
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const viewConfigsAction = getAllByTestId("action.viewProjectConfigs")[0];
+    fireEvent.click(viewConfigsAction);
+    expect(props.actions.viewConfigs).not.toHaveBeenCalled();
+  });
+
+  it("should not call actions.viewDetails if clicked with insufficient permission", () => {
+    props.projects[0].roles = {};
+    const {getAllByTestId} = render(<ProjectCollapsibleList {...props} />);
+    const viewDetailsAction = getAllByTestId("action.viewProject")[0];
+    fireEvent.click(viewDetailsAction);
+    expect(props.actions.viewDetails).not.toHaveBeenCalled();
+  });
+
+  it("should not render the pagination component if totalPages is 1 or below", () => {
+    props.pagination.totalPages = 1;
+    const {queryByTestId} = render(<ProjectCollapsibleList {...props} />);
+    expect(queryByTestId("projectsPagination")).toBeNull();
+  });
+
+  it("should render the pagination component if totalPages is above 1", () => {
+    const {queryByTestId} = render(<ProjectCollapsibleList {...props} />);
+    expect(queryByTestId("projectsPagination")).toBeDefined();
+  });
+
+  it("should call pagination.getPage on page click", () => {
+    const {getByTestId} = render(<ProjectCollapsibleList {...props} />);
+    fireEvent.click(getByTestId("projectsPagination.next"));
+    expect(props.pagination.getPage).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/components/project-collapsible-list/project-collapsible-list.styles.js
+++ b/src/components/project-collapsible-list/project-collapsible-list.styles.js
@@ -4,7 +4,7 @@ import {CollapsiblePanelWrapper, PanelContent} from "../collapsible-panel/collap
 export const ProjectCollapsibleListWrapper = styled.div`
   position: relative;
   display: block;
-  min-height: 730px;
+  min-height: 775px;
 
   & ${CollapsiblePanelWrapper} {
     margin-bottom: 0.5em;

--- a/src/components/project-collapsible-list/project-collapsible-list.styles.js
+++ b/src/components/project-collapsible-list/project-collapsible-list.styles.js
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import {CollapsiblePanelWrapper, PanelContent} from "../collapsible-panel/collapsible-panel.styles";
+
+export const ProjectCollapsibleListWrapper = styled.div`
+  position: relative;
+  display: block;
+  min-height: 730px;
+
+  & ${CollapsiblePanelWrapper} {
+    margin-bottom: 0.5em;
+  }
+
+  & .dataLabel > span {
+    font-weight: bold;
+    margin-right: 10px;
+    display: inline-block;
+    width: 8em;
+  }
+
+  & .dataLabel {
+    width: 50%;
+    display: inline-block;
+  }
+
+  & ${PanelContent} > div {
+    padding: 20px;
+  }
+
+  & .paginationSection {
+    position: absolute;
+    bottom: -2.5em;
+    width: 100%;
+    text-align: center;
+  }
+`;

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -12,7 +12,6 @@ import {getAllStatusNames} from "../../store/actions/status";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
-// import ProjectsTable from "../../components/projects-table/projects-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import {push} from "connected-react-router";
 import MembershipModal from "../../components/membership-modal/membership-modal";
@@ -101,29 +100,6 @@ const Dashboard = (props) => {
 
   const projects = projectsData && projectsData.projects;
   const stories = storiesData && storiesData.stories;
-  // const projectsTableProps = {
-  //   projects,
-  //   actions: {
-  //     addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
-  //     viewProject: (project) => historyPush(`/projects/${project.id}`),
-  //     addStory: (project) => setNewStoryData({project}),
-  //     viewProjectConfigs: (project) => historyPush(`/projects/${project.id}/configs`)
-  //   },
-  //   pagination: {
-  //     itemsPerPage: projectsData && projectsData.itemsPerPage,
-  //     page: projectsData && projectsData.page,
-  //     totalPages: projectsData && projectsData.totalPages,
-      // getPage: async(page) => {
-      //   if(page === projectsData.page)
-      //     return;
-      //   const response = await getDashboardProjects(page, projectsData.itemsPerPage, projectSearchData.searchedValue);
-      //   if(!response.error)
-      //     setProjectsData(response);
-        
-      //   updateQueryString("projectsPage", page);
-      // }
-  //   }
-  // };
 
   const storiesTableProps = {
     stories,
@@ -246,7 +222,14 @@ const Dashboard = (props) => {
               <Tabs.Panel>
                 <SearchBar {...projectsSearchBarProps}/>
                 <ProjectCollapsibleList
+                  dataTestId="projectsList"
                   projects={projects}
+                  actions={{
+                    addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
+                    viewDetails: (project) => historyPush(`/projects/${project.id}`),
+                    addStory: (project) => setNewStoryData({project}),
+                    viewConfigs: (project) => historyPush(`/projects/${project.id}/configs`)
+                  }}
                   pagination={{
                     itemsPerPage: projectsData.itemsPerPage,
                     page: projectsData.page,

--- a/src/containers/dashboard/dashboard.jsx
+++ b/src/containers/dashboard/dashboard.jsx
@@ -12,7 +12,7 @@ import {getAllStatusNames} from "../../store/actions/status";
 import LoadingSpinner from "../../components/loading-spinner/loading-spinner";
 import {faPlus} from "@fortawesome/free-solid-svg-icons";
 import ProjectModal from "../../components/project-modal/project-modal";
-import ProjectsTable from "../../components/projects-table/projects-table";
+// import ProjectsTable from "../../components/projects-table/projects-table";
 import DeleteModal from "../../components/delete-modal/delete-modal";
 import {push} from "connected-react-router";
 import MembershipModal from "../../components/membership-modal/membership-modal";
@@ -23,6 +23,7 @@ import {getDashboardProjects, getDashboardStories} from "../../store/actions/das
 import StoriesTable from "../../components/stories-table/stories-table";
 import SearchBar from "../../components/search-bar/search-bar";
 import {updateQueryString, generateObjectFromSearch, setTitle, onHeaderClick} from "../../utils";
+import ProjectCollapsibleList from "../../components/project-collapsible-list/project-collapsible-list";
 
 const Dashboard = (props) => {
   setTitle("Dashboard");
@@ -100,29 +101,29 @@ const Dashboard = (props) => {
 
   const projects = projectsData && projectsData.projects;
   const stories = storiesData && storiesData.stories;
-  const projectsTableProps = {
-    projects,
-    actions: {
-      addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
-      viewProject: (project) => historyPush(`/projects/${project.id}`),
-      addStory: (project) => setNewStoryData({project}),
-      viewProjectConfigs: (project) => historyPush(`/projects/${project.id}/configs`)
-    },
-    pagination: {
-      itemsPerPage: projectsData && projectsData.itemsPerPage,
-      page: projectsData && projectsData.page,
-      totalPages: projectsData && projectsData.totalPages,
-      getPage: async(page) => {
-        if(page === projectsData.page)
-          return;
-        const response = await getDashboardProjects(page, projectsData.itemsPerPage, projectSearchData.searchedValue);
-        if(!response.error)
-          setProjectsData(response);
+  // const projectsTableProps = {
+  //   projects,
+  //   actions: {
+  //     addMember: (project, adminAllowed) => setMembershipData({project, adminAllowed}),
+  //     viewProject: (project) => historyPush(`/projects/${project.id}`),
+  //     addStory: (project) => setNewStoryData({project}),
+  //     viewProjectConfigs: (project) => historyPush(`/projects/${project.id}/configs`)
+  //   },
+  //   pagination: {
+  //     itemsPerPage: projectsData && projectsData.itemsPerPage,
+  //     page: projectsData && projectsData.page,
+  //     totalPages: projectsData && projectsData.totalPages,
+      // getPage: async(page) => {
+      //   if(page === projectsData.page)
+      //     return;
+      //   const response = await getDashboardProjects(page, projectsData.itemsPerPage, projectSearchData.searchedValue);
+      //   if(!response.error)
+      //     setProjectsData(response);
         
-        updateQueryString("projectsPage", page);
-      }
-    }
-  };
+      //   updateQueryString("projectsPage", page);
+      // }
+  //   }
+  // };
 
   const storiesTableProps = {
     stories,
@@ -244,7 +245,23 @@ const Dashboard = (props) => {
             <Tabs.TabPanels>
               <Tabs.Panel>
                 <SearchBar {...projectsSearchBarProps}/>
-                <ProjectsTable {...projectsTableProps} />
+                <ProjectCollapsibleList
+                  projects={projects}
+                  pagination={{
+                    itemsPerPage: projectsData.itemsPerPage,
+                    page: projectsData.page,
+                    totalPages: projectsData.totalPages,
+                    getPage: async(page) => {
+                      if(page === projectsData.page)
+                        return;
+                      const response = await getDashboardProjects(page, projectsData.itemsPerPage, projectSearchData.searchedValue);
+                      if(!response.error)
+                        setProjectsData(response);
+                      
+                      updateQueryString("projectsPage", page);
+                    }
+                  }}
+                />
               </Tabs.Panel>
               <Tabs.Panel>
                 <SearchBar {...storiesSearchBarProps}/>

--- a/src/containers/dashboard/dashboard.spec.jsx
+++ b/src/containers/dashboard/dashboard.spec.jsx
@@ -162,10 +162,10 @@ describe("<Dashboard />", () => {
     expect(getByText("There are no projects to display")).toBeDefined();
   });
 
-  it("should render the projects table if there are projects to display", async() => {
+  it("should render the projects list if there are projects to display", async() => {
     const {getByTestId} = render(<Dashboard {...props} />, store);
     await waitFor(() => expect(store.dispatch).toHaveBeenCalledTimes(2));
-    expect(getByTestId("projectsTable")).toBeDefined();
+    expect(getByTestId("projectsList")).toBeDefined();
   });
 
   it("should render the MembershipModal if the add member action is clicked", async() => {


### PR DESCRIPTION
This PR comes as a result of the ever-growing data that we have for `Projects` and `Stories` (and whatever may come up in the future). When displaying stories, we have many data points, at least 5. This starts to make the stories-table look very bad and provides a poor user experience because we have data that is useful to display but all of it wont look good thrown onto a table. The ground-work to solving this problem is in this PR:

- Added `CollapsiblePanel` and unit tests.
- Added `ProjectCollapsibleList` and unit tests.
- Updated `Dashboard` to utilize` ProjectCollapsibleList` instead of `ProjectsTable`. Updated unit tests.
- Removed `ProjectsTable` component. It was only used on dashboard and I dont think we have a use for it going forward.
- Added `rotate180` animation.
- Added new `blue` color variant.