### PR TITLE
add logic to render an error if the viewport is too small

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Fragment} from "react";
 import { GlobalStyle } from "./common-styles/base";
 import Navbar from "./containers/navbar/navbar";
 import Notification from "./containers/notification/notification";
@@ -12,21 +12,28 @@ import allRoutes from "./routes";
 
 const CompassApp = () => {
   return (
-    <Provider store={store}>
-      <ConnectedRouter history={history}>
-        <GlobalStyle />
-        <Navbar />
-        <Sidebar />
-        <Notification />
-        <Main>
-          <Switch>
-            {allRoutes.map((routeProps, index) => (
-              <Route key={index} {...routeProps} />
-            ))}
-          </Switch>
-        </Main>
-      </ConnectedRouter>
-    </Provider>
+    <Fragment>
+      <div id="appWrapper">
+        <Provider store={store}>
+          <ConnectedRouter history={history}>
+            <GlobalStyle />
+            <Navbar />
+            <Sidebar />
+            <Notification />
+            <Main>
+              <Switch>
+                {allRoutes.map((routeProps, index) => (
+                  <Route key={index} {...routeProps} />
+                ))}
+              </Switch>
+            </Main>
+          </ConnectedRouter>
+        </Provider>
+      </div>
+      <div id="viewportError">
+        Unsupported Viewport. The Compass application requires a minimum width of 1000 pixels.
+      </div>
+    </Fragment>
   );
 };
 

--- a/src/common-styles/base.js
+++ b/src/common-styles/base.js
@@ -27,8 +27,22 @@ export const GlobalStyle = createGlobalStyle`
     }
   }
 
+  #viewportError {
+    display: none;
+  }
+
   *:focus {
     outline: none;
+  }
+
+  @media screen and (max-width: 999px) {
+    #appWrapper {
+      display: none;
+    }
+
+    #viewportError {
+      display: block;
+    }
   }
 `;
 


### PR DESCRIPTION
My intention with this app has always been that it is for Desktops. This PR contains:
- Added logic to render an error message if the viewport is under 1000px in width.
